### PR TITLE
feat:[littelfs]更新至V.2.11.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,27 +30,27 @@ jobs:
           fetch-depth: 0
 
       # try to get results from tests
-      - uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          workflow: ${{github.event.workflow_run.name}}
-          run_id: ${{github.event.workflow_run.id}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
           pattern: '{sizes,sizes-*}'
           merge-multiple: true
           path: sizes
-      - uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          workflow: ${{github.event.workflow_run.name}}
-          run_id: ${{github.event.workflow_run.id}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
           pattern: '{cov,cov-*}'
           merge-multiple: true
           path: cov
-      - uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          workflow: ${{github.event.workflow_run.name}}
-          run_id: ${{github.event.workflow_run.id}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
           pattern: '{bench,bench-*}'
           merge-multiple: true
           path: bench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.workflow_run.head_sha == github.sha}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         with:
           ref: ${{github.event.workflow_run.head_sha}}
           # need workflow access since we push branches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       github.event.workflow_run.head_sha == github.sha}}
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.workflow_run.head_sha}}
           # need workflow access since we push branches
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       # try to get results from tests
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -38,7 +38,7 @@ jobs:
           pattern: '{sizes,sizes-*}'
           merge-multiple: true
           path: sizes
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -46,7 +46,7 @@ jobs:
           pattern: '{cov,cov-*}'
           merge-multiple: true
           path: cov
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,26 +30,29 @@ jobs:
           fetch-depth: 0
 
       # try to get results from tests
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ${{github.event.workflow_run.name}}
           run_id: ${{github.event.workflow_run.id}}
-          name: sizes
+          pattern: '{sizes,sizes-*}'
+          merge-multiple: true
           path: sizes
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ${{github.event.workflow_run.name}}
           run_id: ${{github.event.workflow_run.id}}
-          name: cov
+          pattern: '{cov,cov-*}'
+          merge-multiple: true
           path: cov
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ${{github.event.workflow_run.name}}
           run_id: ${{github.event.workflow_run.id}}
-          name: bench
+          pattern: '{bench,bench-*}'
+          merge-multiple: true
           path: bench
 
       - name: find-version

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -13,7 +13,7 @@ jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       # generated comment?
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -13,12 +13,13 @@ jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ${{github.event.workflow_run.name}}
           run_id: ${{github.event.workflow_run.id}}
-          name: status
+          pattern: '{status,status-*}'
+          merge-multiple: true
           path: status
       - name: update-status
         continue-on-error: true
@@ -67,12 +68,13 @@ jobs:
 
     steps:
       # generated comment?
-      - uses: dawidd6/action-download-artifact@v2
+      - uses: dawidd6/action-download-artifact@v6
         continue-on-error: true
         with:
           workflow: ${{github.event.workflow_run.name}}
           run_id: ${{github.event.workflow_run.id}}
-          name: comment
+          pattern: '{comment,comment-*}'
+          merge-multiple: true
           path: comment
       - name: update-comment
         continue-on-error: true

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -13,11 +13,11 @@ jobs:
   status:
     runs-on: ubuntu-latest
     steps:
-      - uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          workflow: ${{github.event.workflow_run.name}}
-          run_id: ${{github.event.workflow_run.id}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
           pattern: '{status,status-*}'
           merge-multiple: true
           path: status
@@ -68,11 +68,11 @@ jobs:
 
     steps:
       # generated comment?
-      - uses: dawidd6/action-download-artifact@v6
+      - uses: actions/download-artifact@v4.1.8
         continue-on-error: true
         with:
-          workflow: ${{github.event.workflow_run.name}}
-          run_id: ${{github.event.workflow_run.id}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          run-id: ${{github.event.workflow_run.id}}
           pattern: '{comment,comment-*}'
           merge-multiple: true
           path: comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,7 +273,6 @@ jobs:
             }' | tee status/$(basename $f .csv).json
           done
       - name: upload-status-sizes
-        if: ${{matrix.arch == 'x86_64'}}
         uses: actions/upload-artifact@v4
         with:
           name: status-sizes-${{matrix.arch}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         arch: [x86_64, thumb, mips, powerpc]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -235,7 +235,7 @@ jobs:
 
       # create size statuses
       - name: upload-sizes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: sizes
           path: sizes
@@ -273,7 +273,7 @@ jobs:
             }' | tee status/$(basename $f .csv).json
           done
       - name: upload-status-sizes
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: status
           path: status
@@ -282,7 +282,7 @@ jobs:
       # create cov statuses
       - name: upload-cov
         if: ${{matrix.arch == 'x86_64'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: cov
           path: cov
@@ -319,7 +319,7 @@ jobs:
           done
       - name: upload-status-sizes
         if: ${{matrix.arch == 'x86_64'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: status
           path: status
@@ -336,7 +336,7 @@ jobs:
         pls: [1, 2]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -361,7 +361,7 @@ jobs:
   test-no-intrinsics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -378,7 +378,7 @@ jobs:
   test-multiversion:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -395,7 +395,7 @@ jobs:
   test-lfs2_0:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -414,7 +414,7 @@ jobs:
   test-valgrind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -436,7 +436,7 @@ jobs:
   test-clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -459,7 +459,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -491,7 +491,7 @@ jobs:
 
       # create bench statuses
       - name: upload-bench
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: bench
           path: bench
@@ -525,7 +525,7 @@ jobs:
             }' | tee status/$(basename $f .csv)-$s.json
           done
       - name: upload-status-bench
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: status
           path: status
@@ -535,10 +535,10 @@ jobs:
   test-compat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         if: ${{github.event_name == 'pull_request'}}
       # checkout the current pr target into lfsp
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         if: ${{github.event_name == 'pull_request'}}
         with:
           ref: ${{github.event.pull_request.base.ref}}
@@ -572,7 +572,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -582,7 +582,7 @@ jobs:
           gcc --version
           python3 --version
           fusermount -V
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v2
@@ -622,7 +622,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
       - name: install
         run: |
           # need a few things
@@ -632,12 +632,12 @@ jobs:
           gcc --version
           python3 --version
           fusermount -V
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v2
           path: v2
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v1
@@ -694,7 +694,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, bench]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.7
         if: ${{github.event_name == 'pull_request'}}
       - name: install
         if: ${{github.event_name == 'pull_request'}}
@@ -704,19 +704,19 @@ jobs:
           pip3 install toml
           gcc --version
           python3 --version
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
           name: sizes
           path: sizes
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
           name: cov
           path: cov
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
@@ -862,7 +862,7 @@ jobs:
             body: $comment,
           }' | tee comment/comment.json
       - name: upload-comment
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: comment
           path: comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -709,19 +709,22 @@ jobs:
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
-          name: sizes-x86_64
+          pattern: '{sizes,sizes-*}'
+          merge-multiple: true
           path: sizes
       - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
-          name: cov
+          pattern: '{cov,cov-*}'
+          merge-multiple: true
           path: cov
       - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
-          name: bench
+          pattern: '{bench,bench-*}'
+          merge-multiple: true
           path: bench
 
       # try to find results from tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         arch: [x86_64, thumb, mips, powerpc]
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -235,7 +235,7 @@ jobs:
 
       # create size statuses
       - name: upload-sizes
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: sizes-${{matrix.arch}}
           path: sizes
@@ -274,7 +274,7 @@ jobs:
           done
       - name: upload-status-sizes
         if: ${{matrix.arch == 'x86_64'}}
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: status-sizes-${{matrix.arch}}
           path: status
@@ -283,7 +283,7 @@ jobs:
       # create cov statuses
       - name: upload-cov
         if: ${{matrix.arch == 'x86_64'}}
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: cov
           path: cov
@@ -320,7 +320,7 @@ jobs:
           done
       - name: upload-status-cov
         if: ${{matrix.arch == 'x86_64'}}
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: status-cov
           path: status
@@ -337,7 +337,7 @@ jobs:
         pls: [1, 2]
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -362,7 +362,7 @@ jobs:
   test-no-intrinsics:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -379,7 +379,7 @@ jobs:
   test-multiversion:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -396,7 +396,7 @@ jobs:
   test-lfs2_0:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -415,7 +415,7 @@ jobs:
   test-valgrind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -437,7 +437,7 @@ jobs:
   test-clang:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -460,7 +460,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -492,7 +492,7 @@ jobs:
 
       # create bench statuses
       - name: upload-bench
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: bench
           path: bench
@@ -526,7 +526,7 @@ jobs:
             }' | tee status/$(basename $f .csv)-$s.json
           done
       - name: upload-status-bench
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: status-bench
           path: status
@@ -536,10 +536,10 @@ jobs:
   test-compat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         if: ${{github.event_name == 'pull_request'}}
       # checkout the current pr target into lfsp
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         if: ${{github.event_name == 'pull_request'}}
         with:
           ref: ${{github.event.pull_request.base.ref}}
@@ -573,7 +573,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -583,7 +583,7 @@ jobs:
           gcc --version
           python3 --version
           fusermount -V
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v2
@@ -623,7 +623,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{!endsWith(github.ref, '-prefix')}}
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
       - name: install
         run: |
           # need a few things
@@ -633,12 +633,12 @@ jobs:
           gcc --version
           python3 --version
           fusermount -V
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v2
           path: v2
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         with:
           repository: littlefs-project/littlefs-fuse
           ref: v1
@@ -695,7 +695,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, bench]
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4
         if: ${{github.event_name == 'pull_request'}}
       - name: install
         if: ${{github.event_name == 'pull_request'}}
@@ -705,21 +705,21 @@ jobs:
           pip3 install toml
           gcc --version
           python3 --version
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
           pattern: '{sizes,sizes-*}'
           merge-multiple: true
           path: sizes
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
           pattern: '{cov,cov-*}'
           merge-multiple: true
           path: cov
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v4
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
@@ -866,7 +866,7 @@ jobs:
             body: $comment,
           }' | tee comment/comment.json
       - name: upload-comment
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4
         with:
           name: comment
           path: comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,29 @@ jobs:
         run: |
           CFLAGS="$CFLAGS -DLFS_NO_INTRINSICS" make test
 
+  # run with all trace options enabled to at least make sure these
+  # all compile
+  test-yes-trace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install
+        run: |
+          # need a few things
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc python3 python3-pip
+          pip3 install toml
+          gcc --version
+          python3 --version
+      - name: test-yes-trace
+        run: |
+          CFLAGS="$CFLAGS \
+            -DLFS_YES_TRACE \
+            -DLFS_RAMBD_YES_TRACE \
+            -DLFS_FILEBD_YES_TRACE \
+            -DLFS_RAMBD_YES_TRACE" \
+            make test
+
   # run LFS_MULTIVERSION tests
   test-multiversion:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -374,6 +374,22 @@ jobs:
         run: |
           CFLAGS="$CFLAGS -DLFS_NO_INTRINSICS" make test
 
+  test-shrink:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install
+        run: |
+          # need a few things
+          sudo apt-get update -qq
+          sudo apt-get install -qq gcc python3 python3-pip
+          pip3 install toml
+          gcc --version
+          python3 --version
+      - name: test-no-intrinsics
+        run: |
+          CFLAGS="$CFLAGS -DLFS_SHRINKIFCHEAP" make test
+
   # run with all trace options enabled to at least make sure these
   # all compile
   test-yes-trace:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,7 +237,7 @@ jobs:
       - name: upload-sizes
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: sizes
+          name: sizes-${{matrix.arch}}
           path: sizes
       - name: status-sizes
         run: |
@@ -273,9 +273,10 @@ jobs:
             }' | tee status/$(basename $f .csv).json
           done
       - name: upload-status-sizes
+        if: ${{matrix.arch == 'x86_64'}}
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: status
+          name: status-sizes-${{matrix.arch}}
           path: status
           retention-days: 1
 
@@ -317,11 +318,11 @@ jobs:
               target_step: env.STEP,
             }' | tee status/$(basename $f .csv)-$s.json
           done
-      - name: upload-status-sizes
+      - name: upload-status-cov
         if: ${{matrix.arch == 'x86_64'}}
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: status
+          name: status-cov
           path: status
           retention-days: 1
 
@@ -527,7 +528,7 @@ jobs:
       - name: upload-status-bench
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: status
+          name: status-bench
           path: status
           retention-days: 1
 
@@ -708,7 +709,7 @@ jobs:
         if: ${{github.event_name == 'pull_request'}}
         continue-on-error: true
         with:
-          name: sizes
+          name: sizes-x86_64
           path: sizes
       - uses: actions/download-artifact@v4.1.8
         if: ${{github.event_name == 'pull_request'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -454,8 +454,7 @@ jobs:
           TESTFLAGS="$TESTFLAGS --valgrind --context=1024 -Gdefault -Pnone" \
             make test
 
-  # test that compilation is warning free under clang
-  # run with Clang, mostly to check for Clang-specific warnings
+  # compile/run with Clang, mostly to check for Clang-specific warnings
   test-clang:
     runs-on: ubuntu-latest
     steps:
@@ -469,12 +468,8 @@ jobs:
           python3 --version
       - name: test-clang
         run: |
-          # override CFLAGS since Clang does not support -fcallgraph-info
-          # and -ftrack-macro-expansions
-          make \
-            CC=clang \
-            CFLAGS="$CFLAGS -MMD -g3 -I. -std=c99 -Wall -Wextra -pedantic" \
-            test
+          CC=clang \
+            make test
 
   # run benchmarks
   #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -388,7 +388,7 @@ jobs:
           python3 --version
       - name: test-no-intrinsics
         run: |
-          CFLAGS="$CFLAGS -DLFS_SHRINKIFCHEAP" make test
+          CFLAGS="$CFLAGS -DLFS_SHRINKNONRELOCATING" make test
 
   # run with all trace options enabled to at least make sure these
   # all compile

--- a/Makefile
+++ b/Makefile
@@ -475,6 +475,7 @@ benchmarks-diff: $(BENCH_CSV)
 # rules
 -include $(DEP)
 -include $(TEST_DEP)
+-include $(BENCH_DEP)
 .SUFFIXES:
 .SECONDARY:
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ VALGRIND ?= valgrind
 GDB		 ?= gdb
 PERF	 ?= perf
 
+# guess clang or gcc (clang sometimes masquerades as gcc because of
+# course it does)
+ifneq ($(shell $(CC) --version | grep clang),)
+NO_GCC = 1
+endif
+
 SRC  ?= $(filter-out $(wildcard *.t.* *.b.*),$(wildcard *.c))
 OBJ  := $(SRC:%.c=$(BUILDDIR)/%.o)
 DEP  := $(SRC:%.c=$(BUILDDIR)/%.d)
@@ -63,9 +69,9 @@ CFLAGS += -g3
 CFLAGS += -I.
 CFLAGS += -std=c99 -Wall -Wextra -pedantic
 CFLAGS += -Wmissing-prototypes
-ifeq ($(shell $(CC) --version | grep clang),)
-CFLAGS += -ftrack-macro-expansion=0
+ifndef NO_GCC
 CFLAGS += -fcallgraph-info=su
+CFLAGS += -ftrack-macro-expansion=0
 endif
 
 ifdef DEBUG

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,15 @@ BENCH_PERF  := $(BENCH_RUNNER:%=%.perf)
 BENCH_TRACE := $(BENCH_RUNNER:%=%.trace)
 BENCH_CSV   := $(BENCH_RUNNER:%=%.csv)
 
-CFLAGS += -fcallgraph-info=su
 CFLAGS += -g3
 CFLAGS += -I.
 CFLAGS += -std=c99 -Wall -Wextra -pedantic
 CFLAGS += -Wmissing-prototypes
+ifeq ($(shell $(CC) --version | grep clang),)
 CFLAGS += -ftrack-macro-expansion=0
+CFLAGS += -fcallgraph-info=su
+endif
+
 ifdef DEBUG
 CFLAGS += -O0
 else

--- a/README.md
+++ b/README.md
@@ -251,6 +251,12 @@ License Identifiers that are here available: http://spdx.org/licenses/
   filesystem over USB. Allows mounting littlefs on a host PC without additional
   drivers.
 
+- [ramcrc32bd] - An example block device using littlefs's 32-bit CRC for
+  error-correction.
+
+- [ramrsbd] - An example block device using Reed-Solomon codes for
+  error-correction.
+
 - [Mbed OS] - The easiest way to get started with littlefs is to jump into Mbed
   which already has block device drivers for most forms of embedded storage.
   littlefs is available in Mbed OS as the [LittleFileSystem] class.
@@ -281,6 +287,8 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [mklfs]: https://github.com/whitecatboard/Lua-RTOS-ESP32/tree/master/components/mklfs/src
 [mklittlefs]: https://github.com/earlephilhower/mklittlefs
 [pico-littlefs-usb]: https://github.com/oyama/pico-littlefs-usb
+[ramcrc32bd]: https://github.com/geky/ramcrc32bd
+[ramrsbd]: https://github.com/geky/ramrsbd
 [Mbed OS]: https://github.com/armmbed/mbed-os
 [LittleFileSystem]: https://os.mbed.com/docs/mbed-os/latest/apis/littlefilesystem.html
 [SPIFFS]: https://github.com/pellepl/spiffs

--- a/README.md
+++ b/README.md
@@ -267,7 +267,11 @@ License Identifiers that are here available: http://spdx.org/licenses/
   to create images of the filesystem on your PC. Check if littlefs will fit
   your needs, create images for a later download to the target memory or
   inspect the content of a binary image of the target memory.
-  
+
+- [littlefs-toy] - A command-line tool for creating and working with littlefs
+  images. Uses syntax similar to tar command for ease of use. Supports working
+  on littlefs images embedded inside another file (firmware image, etc).
+
 - [littlefs2-rust] - A Rust wrapper for littlefs. This project allows you
   to use littlefs in a Rust-friendly API, reaping the benefits of Rust's memory
   safety and other guarantees.
@@ -321,6 +325,7 @@ License Identifiers that are here available: http://spdx.org/licenses/
 [littlefs-js]: https://github.com/geky/littlefs-js
 [littlefs-js-demo]:http://littlefs.geky.net/demo.html
 [littlefs-python]: https://pypi.org/project/littlefs-python/
+[littlefs-toy]: https://github.com/tjko/littlefs-toy
 [littlefs2-rust]: https://crates.io/crates/littlefs2
 [nim-littlefs]: https://github.com/Graveflo/nim-littlefs
 [chamelon]: https://github.com/yomimono/chamelon

--- a/README.md
+++ b/README.md
@@ -199,16 +199,45 @@ The tests assume a Linux environment and can be started with make:
 make test
 ```
 
-Tests are defined as C code in toml files in the `tests/` directory.
-When developing a feature or fixing a bug, it is frequently useful to run a single suite of tests.
-To run individual tests or suite of tests:
+Tests are implemented in C in the .toml files found in the `tests` directory.
+When developing a feature or fixing a bug, it is frequently useful to run a
+single test case or suite of tests:
 
 ``` bash
-make test-runner
-python scripts/test.py --help  # See all available options
-python scripts/test.py --list-suites  # prints out all available test suites.
-python scripts/test.py --list-cases  # prints out all available individual test cases.
-python scripts/test.py runners/test_runner test_attrs  # runs the test_attrs suite.
+./scripts/test.py -l runners/test_runner  # list available test suites
+./scripts/test.py -L runners/test_runner test_dirs  # list available test cases
+./scripts/test.py runners/test_runner test_dirs  # run a specific test suite
+```
+
+If an assert fails in a test, test.py will try to print information about the
+failure:
+
+``` bash
+tests/test_dirs.toml:1:failure: test_dirs_root:1g12gg2 (PROG_SIZE=16, ERASE_SIZE=512) failed
+tests/test_dirs.toml:5:assert: assert failed with 0, expected eq 42
+    lfs_mount(&lfs, cfg) => 42;
+```
+
+This includes the test id, which can be passed to test.py to run only that
+specific test permutation:
+
+``` bash
+./scripts/test.py runners/test_runner test_dirs_root:1g12gg2  # run a specific test permutation
+./scripts/test.py runners/test_runner test_dirs_root:1g12gg2 --gdb  # drop into gdb on failure
+```
+
+Some other flags that may be useful:
+
+```bash
+./scripts/test.py runners/test_runner -b -j  # run tests in parallel
+./scripts/test.py runners/test_runner -v -O-  # redirect stdout to stdout
+./scripts/test.py runners/test_runner -ddisk  # capture resulting disk image
+```
+
+See `-h/--help` for a full list of available flags:
+
+``` bash
+./scripts/test.py --help
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ The tests assume a Linux environment and can be started with make:
 make test
 ```
 
+Tests are defined as C code in toml files in the `tests/` directory.
+When developing a feature or fixing a bug, it is frequently useful to run a single suite of tests.
+To run individual tests or suite of tests:
+
+``` bash
+make test-runner
+python scripts/test.py --help  # See all available options
+python scripts/test.py --list-suites  # prints out all available test suites.
+python scripts/test.py --list-cases  # prints out all available individual test cases.
+python scripts/test.py runners/test_runner test_attrs  # runs the test_attrs suite.
+```
+
 ## License
 
 The littlefs is provided under the [BSD-3-Clause] license. See

--- a/bd/lfs_filebd.c
+++ b/bd/lfs_filebd.c
@@ -133,7 +133,7 @@ int lfs_filebd_prog(const struct lfs_config *cfg, lfs_block_t block,
 
 int lfs_filebd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     LFS_FILEBD_TRACE("lfs_filebd_erase(%p, 0x%"PRIx32" (%"PRIu32"))",
-            (void*)cfg, block, ((lfs_file_t*)cfg->context)->cfg->erase_size);
+            (void*)cfg, block, ((lfs_filebd_t*)cfg->context)->cfg->erase_size);
     lfs_filebd_t *bd = cfg->context;
 
     // check if erase is valid

--- a/lfs.c
+++ b/lfs.c
@@ -3725,13 +3725,8 @@ static lfs_soff_t lfs_file_seek_(lfs_t *lfs, lfs_file_t *file,
 
     // if we're only reading and our new offset is still in the file's cache
     // we can avoid flushing and needing to reread the data
-    if (
-#ifndef LFS_READONLY
-        !(file->flags & LFS_F_WRITING)
-#else
-        true
-#endif
-            ) {
+    if ((file->flags & LFS_F_READING)
+            && file->off != lfs->cfg->block_size) {
         int oindex = lfs_ctz_index(lfs, &(lfs_off_t){file->pos});
         lfs_off_t noff = npos;
         int nindex = lfs_ctz_index(lfs, &noff);

--- a/lfs.c
+++ b/lfs.c
@@ -93,6 +93,7 @@ static int lfs_bd_read(lfs_t *lfs,
             // bypass cache?
             diff = lfs_aligndown(diff, lfs->cfg->read_size);
             int err = lfs->cfg->read(lfs->cfg, block, off, data, diff);
+            LFS_ASSERT(err <= 0);
             if (err) {
                 return err;
             }

--- a/lfs.c
+++ b/lfs.c
@@ -5233,7 +5233,7 @@ static int lfs_fs_gc_(lfs_t *lfs) {
 #endif
 
 #ifndef LFS_READONLY
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
 static int lfs_shrink_checkblock(void * data, lfs_block_t block) {
     lfs_size_t threshold = *((lfs_size_t *) data);
     if (block >= threshold) {
@@ -5251,11 +5251,11 @@ static int lfs_fs_grow_(lfs_t *lfs, lfs_size_t block_count) {
     }
 
     
-#ifndef LFS_SHRINKIFCHEAP
+#ifndef LFS_SHRINKNONRELOCATING
     // shrinking is not supported
     LFS_ASSERT(block_count >= lfs->block_count);
 #endif
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_block_t threshold = block_count;
     err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &threshold, true);
     if (err) {

--- a/lfs.c
+++ b/lfs.c
@@ -3932,7 +3932,9 @@ static int lfs_remove_(lfs_t *lfs, const char *path) {
     }
 
     lfs->mlist = dir.next;
-    if (lfs_tag_type3(tag) == LFS_TYPE_DIR) {
+    if (lfs_gstate_hasorphans(&lfs->gstate)) {
+        LFS_ASSERT(lfs_tag_type3(tag) == LFS_TYPE_DIR);
+
         // fix orphan
         err = lfs_fs_preporphans(lfs, -1);
         if (err) {
@@ -4076,8 +4078,10 @@ static int lfs_rename_(lfs_t *lfs, const char *oldpath, const char *newpath) {
     }
 
     lfs->mlist = prevdir.next;
-    if (prevtag != LFS_ERR_NOENT
-            && lfs_tag_type3(prevtag) == LFS_TYPE_DIR) {
+    if (lfs_gstate_hasorphans(&lfs->gstate)) {
+        LFS_ASSERT(prevtag != LFS_ERR_NOENT
+                && lfs_tag_type3(prevtag) == LFS_TYPE_DIR);
+
         // fix orphan
         err = lfs_fs_preporphans(lfs, -1);
         if (err) {

--- a/lfs.c
+++ b/lfs.c
@@ -5234,8 +5234,8 @@ static int lfs_fs_gc_(lfs_t *lfs) {
 
 #ifndef LFS_READONLY
 #ifdef LFS_SHRINKNONRELOCATING
-static int lfs_shrink_checkblock(void * data, lfs_block_t block) {
-    lfs_size_t threshold = *((lfs_size_t *) data);
+static int lfs_shrink_checkblock(void *data, lfs_block_t block) {
+    lfs_size_t threshold = *((lfs_size_t*)data);
     if (block >= threshold) {
         return LFS_ERR_NOTEMPTY;
     }
@@ -5256,10 +5256,11 @@ static int lfs_fs_grow_(lfs_t *lfs, lfs_size_t block_count) {
     LFS_ASSERT(block_count >= lfs->block_count);
 #endif
 #ifdef LFS_SHRINKNONRELOCATING
-    lfs_block_t threshold = block_count;
-    err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &threshold, true);
-    if (err) {
-        return err;
+    if (block_count < lfs->block_count) {
+        err = lfs_fs_traverse_(lfs, lfs_shrink_checkblock, &block_count, true);
+        if (err) {
+            return err;
+        }
     }
 #endif
 

--- a/lfs.c
+++ b/lfs.c
@@ -2128,13 +2128,14 @@ static int lfs_dir_splittingcompact(lfs_t *lfs, lfs_mdir_t *dir,
             // And we cap at half a block to avoid degenerate cases with
             // nearly-full metadata blocks.
             //
+            lfs_size_t metadata_max = (lfs->cfg->metadata_max)
+                    ? lfs->cfg->metadata_max
+                    : lfs->cfg->block_size;
             if (end - split < 0xff
                     && size <= lfs_min(
-                        lfs->cfg->block_size - 40,
+                        metadata_max - 40,
                         lfs_alignup(
-                            (lfs->cfg->metadata_max
-                                ? lfs->cfg->metadata_max
-                                : lfs->cfg->block_size)/2,
+                            metadata_max/2,
                             lfs->cfg->prog_size))) {
                 break;
             }

--- a/lfs.c
+++ b/lfs.c
@@ -3109,7 +3109,7 @@ static int lfs_file_opencfg_(lfs_t *lfs, lfs_file_t *file,
 
         // don't allow trailing slashes
         if (lfs_path_isdir(path)) {
-            err = LFS_ERR_ISDIR;
+            err = LFS_ERR_NOTDIR;
             goto cleanup;
         }
 

--- a/lfs.c
+++ b/lfs.c
@@ -828,9 +828,6 @@ static int lfs_dir_getread(lfs_t *lfs, const lfs_mdir_t *dir,
                 size -= diff;
                 continue;
             }
-
-            // rcache takes priority
-            diff = lfs_min(diff, rcache->off-off);
         }
 
         // load to cache, first condition can no longer fail

--- a/lfs.c
+++ b/lfs.c
@@ -2369,7 +2369,8 @@ fixmlist:;
             if (d->m.pair != pair) {
                 for (int i = 0; i < attrcount; i++) {
                     if (lfs_tag_type3(attrs[i].tag) == LFS_TYPE_DELETE &&
-                            d->id == lfs_tag_id(attrs[i].tag)) {
+                            d->id == lfs_tag_id(attrs[i].tag) &&
+                            d->type != LFS_TYPE_DIR) {
                         d->m.pair[0] = LFS_BLOCK_NULL;
                         d->m.pair[1] = LFS_BLOCK_NULL;
                     } else if (lfs_tag_type3(attrs[i].tag) == LFS_TYPE_DELETE &&

--- a/lfs.c
+++ b/lfs.c
@@ -1522,7 +1522,9 @@ nextname:
                 break;
             }
 
-            if (sufflen == 2 && memcmp(suffix, "..", 2) == 0) {
+            if (sufflen == 1 && memcmp(suffix, ".", 1) == 0) {
+                // noop
+            } else if (sufflen == 2 && memcmp(suffix, "..", 2) == 0) {
                 depth -= 1;
                 if (depth == 0) {
                     name = suffix + sufflen;

--- a/lfs.c
+++ b/lfs.c
@@ -4210,6 +4210,15 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_ASSERT(lfs->cfg->compact_thresh == (lfs_size_t)-1
             || lfs->cfg->compact_thresh <= lfs->cfg->block_size);
 
+    // check that metadata_max is a multiple of read_size and prog_size,
+    // and a factor of the block_size
+    LFS_ASSERT(!lfs->cfg->metadata_max
+            || lfs->cfg->metadata_max % lfs->cfg->read_size == 0);
+    LFS_ASSERT(!lfs->cfg->metadata_max
+            || lfs->cfg->metadata_max % lfs->cfg->prog_size == 0);
+    LFS_ASSERT(!lfs->cfg->metadata_max
+            || lfs->cfg->block_size % lfs->cfg->metadata_max == 0);
+
     // setup read cache
     if (lfs->cfg->read_buffer) {
         lfs->rcache.buffer = lfs->cfg->read_buffer;

--- a/lfs.c
+++ b/lfs.c
@@ -410,16 +410,9 @@ static inline void lfs_gstate_xor(lfs_gstate_t *a, const lfs_gstate_t *b) {
 }
 
 static inline bool lfs_gstate_iszero(const lfs_gstate_t *a) {
-    if (a->tag != 0) {
-        return false;
-    }
-    if (a->pair[0] != 0) {
-        return false;
-    }
-    if (a->pair[1] != 0) {
-        return false;
-    }
-    return true;
+    return a->tag == 0
+            && a->pair[0] == 0
+            && a->pair[1] == 0;
 }
 
 #ifndef LFS_READONLY

--- a/lfs.c
+++ b/lfs.c
@@ -2558,7 +2558,7 @@ static int lfs_dir_orphaningcommit(lfs_t *lfs, lfs_mdir_t *dir,
         if (err != LFS_ERR_NOENT) {
             if (lfs_gstate_hasorphans(&lfs->gstate)) {
                 // next step, clean up orphans
-                err = lfs_fs_preporphans(lfs, -hasparent);
+                err = lfs_fs_preporphans(lfs, -(int8_t)hasparent);
                 if (err) {
                     return err;
                 }

--- a/lfs.c
+++ b/lfs.c
@@ -6288,7 +6288,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
 
     lfs_soff_t res = lfs_file_size_(lfs, file);
 
-    LFS_TRACE("lfs_file_size -> %"PRId32, res);
+    LFS_TRACE("lfs_file_size -> %"PRIu32, res);
     LFS_UNLOCK(lfs->cfg);
     return res;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -1279,6 +1279,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                     if (err == LFS_ERR_CORRUPT) {
                         break;
                     }
+                    return err;
                 }
 
                 lfs_fcrc_fromle32(&fcrc);

--- a/lfs.c
+++ b/lfs.c
@@ -2264,7 +2264,7 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         }
     }
 
-    if (dir->erased || dir->count >= 0xff) {
+    if (dir->erased && dir->count < 0xff) {
         // try to commit
         struct lfs_commit commit = {
             .block = dir->pair[0],

--- a/lfs.c
+++ b/lfs.c
@@ -2333,6 +2333,10 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         lfs->gdisk = lfs->gstate;
         lfs->gdelta = (lfs_gstate_t){0};
 
+        if(dir->count == 0x3ff)
+        {
+            goto compact;
+        }
         goto fixmlist;
     }
 

--- a/lfs.c
+++ b/lfs.c
@@ -5890,7 +5890,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
                 ".block_size=%"PRIu32", .block_count=%"PRIu32", "
-                ".block_cycles=%"PRIu32", .cache_size=%"PRIu32", "
+                ".block_cycles=%"PRId32", .cache_size=%"PRIu32", "
                 ".lookahead_size=%"PRIu32", .read_buffer=%p, "
                 ".prog_buffer=%p, .lookahead_buffer=%p, "
                 ".name_max=%"PRIu32", .file_max=%"PRIu32", "
@@ -5920,7 +5920,7 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
                 ".block_size=%"PRIu32", .block_count=%"PRIu32", "
-                ".block_cycles=%"PRIu32", .cache_size=%"PRIu32", "
+                ".block_cycles=%"PRId32", .cache_size=%"PRIu32", "
                 ".lookahead_size=%"PRIu32", .read_buffer=%p, "
                 ".prog_buffer=%p, .lookahead_buffer=%p, "
                 ".name_max=%"PRIu32", .file_max=%"PRIu32", "
@@ -6057,7 +6057,7 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file, const char *path, int flags) {
         return err;
     }
     LFS_TRACE("lfs_file_open(%p, %p, \"%s\", %x)",
-            (void*)lfs, (void*)file, path, flags);
+            (void*)lfs, (void*)file, path, (unsigned)flags);
     LFS_ASSERT(!lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
     err = lfs_file_open_(lfs, file, path, flags);
@@ -6077,7 +6077,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
     }
     LFS_TRACE("lfs_file_opencfg(%p, %p, \"%s\", %x, %p {"
                  ".buffer=%p, .attrs=%p, .attr_count=%"PRIu32"})",
-            (void*)lfs, (void*)file, path, flags,
+            (void*)lfs, (void*)file, path, (unsigned)flags,
             (void*)cfg, cfg->buffer, (void*)cfg->attrs, cfg->attr_count);
     LFS_ASSERT(!lfs_mlist_isopen(lfs->mlist, (struct lfs_mlist*)file));
 
@@ -6439,7 +6439,7 @@ int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
                 ".block_size=%"PRIu32", .block_count=%"PRIu32", "
-                ".block_cycles=%"PRIu32", .cache_size=%"PRIu32", "
+                ".block_cycles=%"PRId32", .cache_size=%"PRIu32", "
                 ".lookahead_size=%"PRIu32", .read_buffer=%p, "
                 ".prog_buffer=%p, .lookahead_buffer=%p, "
                 ".name_max=%"PRIu32", .file_max=%"PRIu32", "

--- a/lfs.c
+++ b/lfs.c
@@ -5225,7 +5225,9 @@ static int lfs_fs_gc_(lfs_t *lfs) {
     }
 
     // try to populate the lookahead buffer, unless it's already full
-    if (lfs->lookahead.size < lfs_min(8 * lfs->cfg->lookahead_size, lfs->block_count)) {
+    if (lfs->lookahead.size < lfs_min(
+            8 * lfs->cfg->lookahead_size,
+            lfs->block_count)) {
         err = lfs_alloc_scan(lfs);
         if (err) {
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -3664,22 +3664,16 @@ static lfs_ssize_t lfs_file_write_(lfs_t *lfs, lfs_file_t *file,
 static lfs_soff_t lfs_file_seek_(lfs_t *lfs, lfs_file_t *file,
         lfs_soff_t off, int whence) {
     // find new pos
+    //
+    // fortunately for us, littlefs is limited to 31-bit file sizes, so we
+    // don't have to worry too much about integer overflow
     lfs_off_t npos = file->pos;
     if (whence == LFS_SEEK_SET) {
         npos = off;
     } else if (whence == LFS_SEEK_CUR) {
-        if ((lfs_soff_t)file->pos + off < 0) {
-            return LFS_ERR_INVAL;
-        } else {
-            npos = file->pos + off;
-        }
+        npos = file->pos + (lfs_off_t)off;
     } else if (whence == LFS_SEEK_END) {
-        lfs_soff_t res = lfs_file_size_(lfs, file) + off;
-        if (res < 0) {
-            return LFS_ERR_INVAL;
-        } else {
-            npos = res;
-        }
+        npos = (lfs_off_t)lfs_file_size_(lfs, file) + (lfs_off_t)off;
     }
 
     if (npos > lfs->file_max) {

--- a/lfs.c
+++ b/lfs.c
@@ -1492,6 +1492,11 @@ static lfs_stag_t lfs_dir_find(lfs_t *lfs, lfs_mdir_t *dir,
     dir->tail[0] = lfs->root[0];
     dir->tail[1] = lfs->root[1];
 
+    // empty paths are not allowed
+    if (*name == '\0') {
+        return LFS_ERR_INVAL;
+    }
+
     while (true) {
 nextname:
         // skip slashes if we're a directory
@@ -1538,7 +1543,7 @@ nextname:
         }
 
         // found path
-        if (name[0] == '\0') {
+        if (*name == '\0') {
             return tag;
         }
 

--- a/lfs.c
+++ b/lfs.c
@@ -5225,7 +5225,7 @@ static int lfs_fs_gc_(lfs_t *lfs) {
     }
 
     // try to populate the lookahead buffer, unless it's already full
-    if (lfs->lookahead.size < 8*lfs->cfg->lookahead_size) {
+    if (lfs->lookahead.size < lfs_min(8 * lfs->cfg->lookahead_size, lfs->block_count)) {
         err = lfs_alloc_scan(lfs);
         if (err) {
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -404,16 +404,20 @@ struct lfs_diskoff {
 
 // operations on global state
 static inline void lfs_gstate_xor(lfs_gstate_t *a, const lfs_gstate_t *b) {
-    for (int i = 0; i < 3; i++) {
-        ((uint32_t*)a)[i] ^= ((const uint32_t*)b)[i];
-    }
+    a->tag ^= b->tag;
+    a->pair[0] ^= b->pair[0];
+    a->pair[1] ^= b->pair[1];
 }
 
 static inline bool lfs_gstate_iszero(const lfs_gstate_t *a) {
-    for (int i = 0; i < 3; i++) {
-        if (((uint32_t*)a)[i] != 0) {
-            return false;
-        }
+    if (a->tag != 0) {
+        return false;
+    }
+    if (a->pair[0] != 0) {
+        return false;
+    }
+    if (a->pair[1] != 0) {
+        return false;
     }
     return true;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -1500,11 +1500,15 @@ nextname:
         }
         lfs_size_t namelen = strcspn(name, "/");
 
-        // skip '.' and root '..'
-        if ((namelen == 1 && memcmp(name, ".", 1) == 0) ||
-            (namelen == 2 && memcmp(name, "..", 2) == 0)) {
+        // skip '.'
+        if (namelen == 1 && memcmp(name, ".", 1) == 0) {
             name += namelen;
             goto nextname;
+        }
+
+        // error on unmatched '..', trying to go above root?
+        if (namelen == 2 && memcmp(name, "..", 2) == 0) {
+            return LFS_ERR_INVAL;
         }
 
         // skip if matched by '..' in name

--- a/lfs.c
+++ b/lfs.c
@@ -2264,7 +2264,7 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         }
     }
 
-    if (dir->erased) {
+    if (dir->erased || dir->count >= 0xff) {
         // try to commit
         struct lfs_commit commit = {
             .block = dir->pair[0],
@@ -2333,10 +2333,6 @@ static int lfs_dir_relocatingcommit(lfs_t *lfs, lfs_mdir_t *dir,
         lfs->gdisk = lfs->gstate;
         lfs->gdelta = (lfs_gstate_t){0};
 
-        if(dir->count == 0x3ff)
-        {
-            goto compact;
-        }
         goto fixmlist;
     }
 

--- a/lfs.c
+++ b/lfs.c
@@ -739,6 +739,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
         int err = lfs_bd_read(lfs,
                 NULL, &lfs->rcache, sizeof(ntag),
                 dir->pair[0], off, &ntag, sizeof(ntag));
+        LFS_ASSERT(err <= 0);
         if (err) {
             return err;
         }
@@ -767,6 +768,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
             err = lfs_bd_read(lfs,
                     NULL, &lfs->rcache, diff,
                     dir->pair[0], off+sizeof(tag)+goff, gbuffer, diff);
+            LFS_ASSERT(err <= 0);
             if (err) {
                 return err;
             }

--- a/lfs.c
+++ b/lfs.c
@@ -4217,6 +4217,14 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     // which littlefs currently does not support
     LFS_ASSERT((bool)0x80000000);
 
+    // check that the required io functions are provided
+    LFS_ASSERT(lfs->cfg->read != NULL);
+#ifndef LFS_READONLY
+    LFS_ASSERT(lfs->cfg->prog != NULL);
+    LFS_ASSERT(lfs->cfg->erase != NULL);
+    LFS_ASSERT(lfs->cfg->sync != NULL);
+#endif
+
     // validate that the lfs-cfg sizes were initiated properly before
     // performing any arithmetic logics with them
     LFS_ASSERT(lfs->cfg->read_size != 0);

--- a/lfs.h
+++ b/lfs.h
@@ -21,7 +21,7 @@ extern "C"
 // Software library version
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_VERSION 0x00020009
+#define LFS_VERSION 0x0002000a
 #define LFS_VERSION_MAJOR (0xffff & (LFS_VERSION >> 16))
 #define LFS_VERSION_MINOR (0xffff & (LFS_VERSION >>  0))
 

--- a/lfs.h
+++ b/lfs.h
@@ -766,11 +766,11 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
-// if LFS_SHRINKIFCHEAP is defined, this function will also accept
+// If LFS_SHRINKIFCHEAP is defined, this function will also accept
 // block_counts smaller than the current configuration, after checking
 // that none of the blocks that are being removed are in use.
-//
-// Note: This is irreversible.
+// Note that littlefs's pseudorandom block allocation means that
+// this is very unlikely to work in the general case.
 //
 // Returns a negative error code on failure.
 int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);

--- a/lfs.h
+++ b/lfs.h
@@ -21,7 +21,7 @@ extern "C"
 // Software library version
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_VERSION 0x0002000a
+#define LFS_VERSION 0x0002000b
 #define LFS_VERSION_MAJOR (0xffff & (LFS_VERSION >> 16))
 #define LFS_VERSION_MINOR (0xffff & (LFS_VERSION >>  0))
 

--- a/lfs.h
+++ b/lfs.h
@@ -766,21 +766,14 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
+// if LFS_SHRINKIFCHEAP is defined, this function will also accept
+// block_counts smaller than the current configuration, after checking
+// that none of the blocks that are being removed are in use.
+//
 // Note: This is irreversible.
 //
 // Returns a negative error code on failure.
 int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);
-#endif
-
-#ifndef LFS_READONLY
-// Shrinks the filesystem to a new size, updating the superblock with the new
-// block count.
-//
-// Note: This first checks that none of the blocks that are being removed are in use
-// and will fail if it is the case
-//
-// Returns a negative error code on failure.
-int lfs_fs_shrink(lfs_t *lfs, lfs_size_t block_count);
 #endif
 
 #ifndef LFS_READONLY

--- a/lfs.h
+++ b/lfs.h
@@ -773,6 +773,17 @@ int lfs_fs_grow(lfs_t *lfs, lfs_size_t block_count);
 #endif
 
 #ifndef LFS_READONLY
+// Shrinks the filesystem to a new size, updating the superblock with the new
+// block count.
+//
+// Note: This first checks that none of the blocks that are being removed are in use
+// and will fail if it is the case
+//
+// Returns a negative error code on failure.
+int lfs_fs_shrink(lfs_t *lfs, lfs_size_t block_count);
+#endif
+
+#ifndef LFS_READONLY
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs
 //

--- a/lfs.h
+++ b/lfs.h
@@ -766,7 +766,7 @@ int lfs_fs_gc(lfs_t *lfs);
 // Grows the filesystem to a new size, updating the superblock with the new
 // block count.
 //
-// If LFS_SHRINKIFCHEAP is defined, this function will also accept
+// If LFS_SHRINKNONRELOCATING is defined, this function will also accept
 // block_counts smaller than the current configuration, after checking
 // that none of the blocks that are being removed are in use.
 // Note that littlefs's pseudorandom block allocation means that

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -195,10 +195,10 @@ static inline uint32_t lfs_fromle32(uint32_t a) {
     (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
     return __builtin_bswap32(a);
 #else
-    return (((uint8_t*)&a)[0] <<  0) |
-           (((uint8_t*)&a)[1] <<  8) |
-           (((uint8_t*)&a)[2] << 16) |
-           (((uint8_t*)&a)[3] << 24);
+    return ((uint32_t)((uint8_t*)&a)[0] <<  0) |
+           ((uint32_t)((uint8_t*)&a)[1] <<  8) |
+           ((uint32_t)((uint8_t*)&a)[2] << 16) |
+           ((uint32_t)((uint8_t*)&a)[3] << 24);
 #endif
 }
 
@@ -218,10 +218,10 @@ static inline uint32_t lfs_frombe32(uint32_t a) {
     (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
     return a;
 #else
-    return (((uint8_t*)&a)[0] << 24) |
-           (((uint8_t*)&a)[1] << 16) |
-           (((uint8_t*)&a)[2] <<  8) |
-           (((uint8_t*)&a)[3] <<  0);
+    return ((uint32_t)((uint8_t*)&a)[0] << 24) |
+           ((uint32_t)((uint8_t*)&a)[1] << 16) |
+           ((uint32_t)((uint8_t*)&a)[2] <<  8) |
+           ((uint32_t)((uint8_t*)&a)[3] <<  0);
 #endif
 }
 

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -8,6 +8,9 @@
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H
 
+#define LFS_STRINGIZE(x) LFS_STRINGIZE2(x)
+#define LFS_STRINGIZE2(x) #x
+
 // Users can override lfs_util.h with their own configuration by defining
 // LFS_CONFIG as a header file to include (-DLFS_CONFIG=lfs_config.h).
 //
@@ -15,10 +18,25 @@
 // provided by the config file. To start, I would suggest copying lfs_util.h
 // and modifying as needed.
 #ifdef LFS_CONFIG
-#define LFS_STRINGIZE(x) LFS_STRINGIZE2(x)
-#define LFS_STRINGIZE2(x) #x
 #include LFS_STRINGIZE(LFS_CONFIG)
 #else
+
+// Alternatively, users can provide a header file which defines
+// macros and other things consumed by littlefs.
+//
+// For example, provide my_defines.h, which contains
+// something like:
+//
+// #include <stddef.h>
+// extern void *my_malloc(size_t sz);
+// #define LFS_MALLOC(sz) my_malloc(sz)
+//
+// And build littlefs with the header by defining LFS_USER_DEFINES.
+// (-DLFS_USER_DEFINES=my_defines.h)
+
+#ifdef LFS_USER_DEFINES
+#include LFS_STRINGIZE(LFS_USER_DEFINES)
+#endif
 
 // System includes
 #include <stdint.h>

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -31,11 +31,11 @@
 // extern void *my_malloc(size_t sz);
 // #define LFS_MALLOC(sz) my_malloc(sz)
 //
-// And build littlefs with the header by defining LFS_USER_DEFINES.
-// (-DLFS_USER_DEFINES=my_defines.h)
+// And build littlefs with the header by defining LFS_DEFINES.
+// (-DLFS_DEFINES=my_defines.h)
 
-#ifdef LFS_USER_DEFINES
-#include LFS_STRINGIZE(LFS_USER_DEFINES)
+#ifdef LFS_DEFINES
+#include LFS_STRINGIZE(LFS_DEFINES)
 #endif
 
 // System includes

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -231,8 +231,8 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 
 // Calculate CRC-32 with polynomial = 0x04c11db7
 #ifdef LFS_CRC
-uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
-    return LFS_CRC(crc, buffer, size)
+static inline uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size) {
+    return LFS_CRC(crc, buffer, size);
 }
 #else
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);

--- a/runners/bench_runner.c
+++ b/runners/bench_runner.c
@@ -1322,6 +1322,7 @@ void perm_run(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     };
 

--- a/runners/bench_runner.c
+++ b/runners/bench_runner.c
@@ -123,8 +123,13 @@ typedef struct bench_id {
 
 
 // bench suites are linked into a custom ld section
+#if defined(__APPLE__)
+extern struct bench_suite __start__bench_suites __asm("section$start$__DATA$_bench_suites");
+extern struct bench_suite __stop__bench_suites __asm("section$end$__DATA$_bench_suites");
+#else
 extern struct bench_suite __start__bench_suites;
 extern struct bench_suite __stop__bench_suites;
+#endif
 
 const struct bench_suite *bench_suites = &__start__bench_suites;
 #define BENCH_SUITE_COUNT \

--- a/runners/bench_runner.h
+++ b/runners/bench_runner.h
@@ -96,12 +96,13 @@ intmax_t bench_define(size_t define);
 #define CACHE_SIZE_i         6
 #define LOOKAHEAD_SIZE_i     7
 #define COMPACT_THRESH_i     8
-#define INLINE_MAX_i         9
-#define BLOCK_CYCLES_i       10
-#define ERASE_VALUE_i        11
-#define ERASE_CYCLES_i       12
-#define BADBLOCK_BEHAVIOR_i  13
-#define POWERLOSS_BEHAVIOR_i 14
+#define METADATA_MAX_i       9
+#define INLINE_MAX_i         10
+#define BLOCK_CYCLES_i       11
+#define ERASE_VALUE_i        12
+#define ERASE_CYCLES_i       13
+#define BADBLOCK_BEHAVIOR_i  14
+#define POWERLOSS_BEHAVIOR_i 15
 
 #define READ_SIZE           bench_define(READ_SIZE_i)
 #define PROG_SIZE           bench_define(PROG_SIZE_i)
@@ -112,6 +113,7 @@ intmax_t bench_define(size_t define);
 #define CACHE_SIZE          bench_define(CACHE_SIZE_i)
 #define LOOKAHEAD_SIZE      bench_define(LOOKAHEAD_SIZE_i)
 #define COMPACT_THRESH      bench_define(COMPACT_THRESH_i)
+#define METADATA_MAX        bench_define(METADATA_MAX_i)
 #define INLINE_MAX          bench_define(INLINE_MAX_i)
 #define BLOCK_CYCLES        bench_define(BLOCK_CYCLES_i)
 #define ERASE_VALUE         bench_define(ERASE_VALUE_i)
@@ -129,6 +131,7 @@ intmax_t bench_define(size_t define);
     BENCH_DEF(CACHE_SIZE,         lfs_max(64,lfs_max(READ_SIZE,PROG_SIZE))) \
     BENCH_DEF(LOOKAHEAD_SIZE,     16) \
     BENCH_DEF(COMPACT_THRESH,     0) \
+    BENCH_DEF(METADATA_MAX,       0) \
     BENCH_DEF(INLINE_MAX,         0) \
     BENCH_DEF(BLOCK_CYCLES,       -1) \
     BENCH_DEF(ERASE_VALUE,        0xff) \
@@ -137,7 +140,7 @@ intmax_t bench_define(size_t define);
     BENCH_DEF(POWERLOSS_BEHAVIOR, LFS_EMUBD_POWERLOSS_NOOP)
 
 #define BENCH_GEOMETRY_DEFINE_COUNT 4
-#define BENCH_IMPLICIT_DEFINE_COUNT 15
+#define BENCH_IMPLICIT_DEFINE_COUNT 16
 
 
 #endif

--- a/runners/test_runner.c
+++ b/runners/test_runner.c
@@ -1347,6 +1347,7 @@ static void run_powerloss_none(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
@@ -1425,6 +1426,7 @@ static void run_powerloss_linear(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
@@ -1520,6 +1522,7 @@ static void run_powerloss_log(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
@@ -1613,6 +1616,7 @@ static void run_powerloss_cycles(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,
@@ -1804,6 +1808,7 @@ static void run_powerloss_exhaustive(
         .cache_size         = CACHE_SIZE,
         .lookahead_size     = LOOKAHEAD_SIZE,
         .compact_thresh     = COMPACT_THRESH,
+        .metadata_max       = METADATA_MAX,
         .inline_max         = INLINE_MAX,
     #ifdef LFS_MULTIVERSION
         .disk_version       = DISK_VERSION,

--- a/runners/test_runner.c
+++ b/runners/test_runner.c
@@ -136,8 +136,13 @@ typedef struct test_id {
 
 
 // test suites are linked into a custom ld section
+#if defined(__APPLE__)
+extern struct test_suite __start__test_suites __asm("section$start$__DATA$_test_suites");
+extern struct test_suite __stop__test_suites __asm("section$end$__DATA$_test_suites");
+#else
 extern struct test_suite __start__test_suites;
 extern struct test_suite __stop__test_suites;
+#endif
 
 const struct test_suite *test_suites = &__start__test_suites;
 #define TEST_SUITE_COUNT \

--- a/runners/test_runner.h
+++ b/runners/test_runner.h
@@ -89,13 +89,14 @@ intmax_t test_define(size_t define);
 #define CACHE_SIZE_i         6
 #define LOOKAHEAD_SIZE_i     7
 #define COMPACT_THRESH_i     8
-#define INLINE_MAX_i         9
-#define BLOCK_CYCLES_i       10
-#define ERASE_VALUE_i        11
-#define ERASE_CYCLES_i       12
-#define BADBLOCK_BEHAVIOR_i  13
-#define POWERLOSS_BEHAVIOR_i 14
-#define DISK_VERSION_i       15
+#define METADATA_MAX_i       9
+#define INLINE_MAX_i         10
+#define BLOCK_CYCLES_i       11
+#define ERASE_VALUE_i        12
+#define ERASE_CYCLES_i       13
+#define BADBLOCK_BEHAVIOR_i  14
+#define POWERLOSS_BEHAVIOR_i 15
+#define DISK_VERSION_i       16
 
 #define READ_SIZE           TEST_DEFINE(READ_SIZE_i)
 #define PROG_SIZE           TEST_DEFINE(PROG_SIZE_i)
@@ -106,6 +107,7 @@ intmax_t test_define(size_t define);
 #define CACHE_SIZE          TEST_DEFINE(CACHE_SIZE_i)
 #define LOOKAHEAD_SIZE      TEST_DEFINE(LOOKAHEAD_SIZE_i)
 #define COMPACT_THRESH      TEST_DEFINE(COMPACT_THRESH_i)
+#define METADATA_MAX        TEST_DEFINE(METADATA_MAX_i)
 #define INLINE_MAX          TEST_DEFINE(INLINE_MAX_i)
 #define BLOCK_CYCLES        TEST_DEFINE(BLOCK_CYCLES_i)
 #define ERASE_VALUE         TEST_DEFINE(ERASE_VALUE_i)
@@ -124,6 +126,7 @@ intmax_t test_define(size_t define);
     TEST_DEF(CACHE_SIZE,         lfs_max(64,lfs_max(READ_SIZE,PROG_SIZE))) \
     TEST_DEF(LOOKAHEAD_SIZE,     16) \
     TEST_DEF(COMPACT_THRESH,     0) \
+    TEST_DEF(METADATA_MAX,       0) \
     TEST_DEF(INLINE_MAX,         0) \
     TEST_DEF(BLOCK_CYCLES,       -1) \
     TEST_DEF(ERASE_VALUE,        0xff) \
@@ -133,7 +136,7 @@ intmax_t test_define(size_t define);
     TEST_DEF(DISK_VERSION,       0)
 
 #define TEST_GEOMETRY_DEFINE_COUNT 4
-#define TEST_IMPLICIT_DEFINE_COUNT 16
+#define TEST_IMPLICIT_DEFINE_COUNT 17
 
 
 #endif

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -404,12 +404,15 @@ def compile(bench_paths, **args):
                         f.writeln()
 
                 # create suite struct
-                #
+                f.writeln('#if defined(__APPLE__)')
+                f.writeln('__attribute__((section("__DATA,_bench_suites")))')
+                f.writeln('#else')
                 # note we place this in the custom bench_suites section with
                 # minimum alignment, otherwise GCC ups the alignment to
                 # 32-bytes for some reason
                 f.writeln('__attribute__((section("_bench_suites"), '
                     'aligned(1)))')
+                f.writeln('#endif')
                 f.writeln('const struct bench_suite __bench__%s__suite = {'
                     % suite.name)
                 f.writeln(4*' '+'.name = "%s",' % suite.name)

--- a/scripts/changeprefix.py
+++ b/scripts/changeprefix.py
@@ -73,7 +73,7 @@ def changefile(from_prefix, to_prefix, from_path, to_path, *,
         shutil.copystat(from_path, to_path)
 
     if to_path_temp:
-        os.rename(to_path, from_path)
+        shutil.move(to_path, from_path)
     elif from_path != '-':
         os.remove(from_path)
 

--- a/scripts/prettyasserts.py
+++ b/scripts/prettyasserts.py
@@ -35,10 +35,10 @@ LEXEMES = {
     'assert':   ['assert'],
     'arrow':    ['=>'],
     'string':   [r'"(?:\\.|[^"])*"', r"'(?:\\.|[^'])\'"],
-    'paren':    ['\(', '\)'],
+    'paren':    [r'\(', r'\)'],
     'cmp':      CMP.keys(),
-    'logic':    ['\&\&', '\|\|'],
-    'sep':      [':', ';', '\{', '\}', ','],
+    'logic':    [r'\&\&', r'\|\|'],
+    'sep':      [':', ';', r'\{', r'\}', ','],
     'op':       ['->'], # specifically ops that conflict with cmp
 }
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -412,12 +412,15 @@ def compile(test_paths, **args):
                         f.writeln()
 
                 # create suite struct
-                #
+                f.writeln('#if defined(__APPLE__)')
+                f.writeln('__attribute__((section("__DATA,_test_suites")))')
+                f.writeln('#else')
                 # note we place this in the custom test_suites section with
                 # minimum alignment, otherwise GCC ups the alignment to
                 # 32-bytes for some reason
                 f.writeln('__attribute__((section("_test_suites"), '
                     'aligned(1)))')
+                f.writeln('#endif')
                 f.writeln('const struct test_suite __test__%s__suite = {'
                     % suite.name)
                 f.writeln(4*' '+'.name = "%s",' % suite.name)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -102,9 +102,9 @@ class TestCase:
                 # the runner itself.
                 for v_ in csplit(v):
                     m = re.search(r'\brange\b\s*\('
-                        '(?P<start>[^,\s]*)'
-                        '\s*(?:,\s*(?P<stop>[^,\s]*)'
-                        '\s*(?:,\s*(?P<step>[^,\s]*)\s*)?)?\)',
+                        r'(?P<start>[^,\s]*)'
+                        r'\s*(?:,\s*(?P<stop>[^,\s]*)'
+                        r'\s*(?:,\s*(?P<step>[^,\s]*)\s*)?)?\)',
                         v_)
                     if m:
                         start = (int(m.group('start'), 0)
@@ -163,8 +163,8 @@ class TestSuite:
             code_linenos = []
             for i, line in enumerate(f):
                 match = re.match(
-                    '(?P<case>\[\s*cases\s*\.\s*(?P<name>\w+)\s*\])'
-                        '|' '(?P<code>code\s*=)',
+                    r'(?P<case>\[\s*cases\s*\.\s*(?P<name>\w+)\s*\])'
+                        r'|' r'(?P<code>code\s*=)',
                     line)
                 if match and match.group('case'):
                     case_linenos.append((i+1, match.group('name')))
@@ -602,9 +602,9 @@ def find_perms(runner_, ids=[], **args):
         errors='replace',
         close_fds=False)
     pattern = re.compile(
-        '^(?P<case>[^\s]+)'
-            '\s+(?P<flags>[^\s]+)'
-            '\s+(?P<filtered>\d+)/(?P<perms>\d+)')
+        r'^(?P<case>[^\s]+)'
+            r'\s+(?P<flags>[^\s]+)'
+            r'\s+(?P<filtered>\d+)/(?P<perms>\d+)')
     # skip the first line
     for line in it.islice(proc.stdout, 1, None):
         m = pattern.match(line)
@@ -632,8 +632,8 @@ def find_perms(runner_, ids=[], **args):
         errors='replace',
         close_fds=False)
     pattern = re.compile(
-        '^(?P<case>[^\s]+)'
-            '\s+(?P<path>[^:]+):(?P<lineno>\d+)')
+        r'^(?P<case>[^\s]+)'
+            r'\s+(?P<path>[^:]+):(?P<lineno>\d+)')
     # skip the first line
     for line in it.islice(proc.stdout, 1, None):
         m = pattern.match(line)
@@ -676,8 +676,8 @@ def find_path(runner_, id, **args):
         errors='replace',
         close_fds=False)
     pattern = re.compile(
-        '^(?P<case>[^\s]+)'
-            '\s+(?P<path>[^:]+):(?P<lineno>\d+)')
+        r'^(?P<case>[^\s]+)'
+            r'\s+(?P<path>[^:]+):(?P<lineno>\d+)')
     # skip the first line
     for line in it.islice(proc.stdout, 1, None):
         m = pattern.match(line)
@@ -706,7 +706,7 @@ def find_defines(runner_, id, **args):
         errors='replace',
         close_fds=False)
     defines = co.OrderedDict()
-    pattern = re.compile('^(?P<define>\w+)=(?P<value>.+)')
+    pattern = re.compile(r'^(?P<define>\w+)=(?P<value>.+)')
     for line in proc.stdout:
         m = pattern.match(line)
         if m:
@@ -781,12 +781,12 @@ def run_stage(name, runner_, ids, stdout_, trace_, output_, **args):
     failures = []
     killed = False
 
-    pattern = re.compile('^(?:'
-            '(?P<op>running|finished|skipped|powerloss) '
-                '(?P<id>(?P<case>[^:]+)[^\s]*)'
-            '|' '(?P<path>[^:]+):(?P<lineno>\d+):(?P<op_>assert):'
-                ' *(?P<message>.*)'
-        ')$')
+    pattern = re.compile(r'^(?:'
+            r'(?P<op>running|finished|skipped|powerloss) '
+                r'(?P<id>(?P<case>[^:]+)[^\s]*)'
+            r'|' r'(?P<path>[^:]+):(?P<lineno>\d+):(?P<op_>assert):'
+                r' *(?P<message>.*)'
+        r')$')
     locals = th.local()
     children = set()
 

--- a/tests/test_dirs.toml
+++ b/tests/test_dirs.toml
@@ -725,6 +725,82 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
+[cases.test_dirs_remove_read]
+defines.N = 10
+if = 'N < BLOCK_COUNT/2'
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_mkdir(&lfs, "prickly-pear") => 0;
+    for (int i = 0; i < N; i++) {
+        char path[1024];
+        sprintf(path, "prickly-pear/cactus%03d", i);
+        lfs_mkdir(&lfs, path) => 0;
+    }
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "prickly-pear") => 0;
+    struct lfs_info info;
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, ".") == 0);
+    lfs_dir_read(&lfs, &dir, &info) => 1;
+    assert(info.type == LFS_TYPE_DIR);
+    assert(strcmp(info.name, "..") == 0);
+    for (int i = 0; i < N; i++) {
+        char path[1024];
+        sprintf(path, "cactus%03d", i);
+        lfs_dir_read(&lfs, &dir, &info) => 1;
+        assert(info.type == LFS_TYPE_DIR);
+        assert(strcmp(info.name, path) == 0);
+    }
+    lfs_dir_read(&lfs, &dir, &info) => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_unmount(&lfs);
+
+    for (lfs_size_t k = 0; k < N; k++) {
+        for (lfs_size_t j = 0; j < N; j++) {
+            lfs_mount(&lfs, cfg) => 0;
+            lfs_dir_open(&lfs, &dir, "prickly-pear") => 0;
+            lfs_dir_read(&lfs, &dir, &info) => 1;
+            assert(info.type == LFS_TYPE_DIR);
+            assert(strcmp(info.name, ".") == 0);
+            lfs_dir_read(&lfs, &dir, &info) => 1;
+            assert(info.type == LFS_TYPE_DIR);
+            assert(strcmp(info.name, "..") == 0);
+            // iterate over dirs < j
+            for (unsigned i = 0; i < j; i++) {
+                char path[1024];
+                sprintf(path, "cactus%03d", i);
+                lfs_dir_read(&lfs, &dir, &info) => 1;
+                assert(info.type == LFS_TYPE_DIR);
+                assert(strcmp(info.name, path) == 0);
+            }
+
+            // remove k while iterating
+            char path[1024];
+            sprintf(path, "prickly-pear/cactus%03d", k);
+            lfs_remove(&lfs, path) => 0;
+
+            // iterate over dirs >= j
+            for (unsigned i = j; i < ((k >= j) ? N-1 : N); i++) {
+                char path[1024];
+                sprintf(path, "cactus%03d", (k >= j && i >= k) ? i+1 : i);
+                lfs_dir_read(&lfs, &dir, &info) => 1;
+                assert(info.type == LFS_TYPE_DIR);
+                assert(strcmp(info.name, path) == 0);
+            }
+            lfs_dir_read(&lfs, &dir, &info) => 0;
+            lfs_dir_close(&lfs, &dir) => 0;
+
+            // recreate k
+            sprintf(path, "prickly-pear/cactus%03d", k);
+            lfs_mkdir(&lfs, path) => 0;
+            lfs_unmount(&lfs) => 0;
+        }
+    }
+'''
+
 [cases.test_dirs_other_errors]
 code = '''
     lfs_t lfs;

--- a/tests/test_orphans.toml
+++ b/tests/test_orphans.toml
@@ -207,7 +207,8 @@ code = '''
 [cases.test_orphans_reentrant]
 reentrant = true
 # TODO fix this case, caused by non-DAG trees
-if = '!(DEPTH == 3 && CACHE_SIZE != 64)'
+# NOTE the second condition is required
+if = '!(DEPTH == 3 && CACHE_SIZE != 64) && 2*FILES < BLOCK_COUNT'
 defines = [
     {FILES=6,  DEPTH=1, CYCLES=20},
     {FILES=26, DEPTH=1, CYCLES=20},
@@ -262,6 +263,72 @@ code = '''
                 strcpy(path, full_path);
                 path[2*d+2] = '\0';
                 err = lfs_remove(&lfs, path);
+                assert(!err || err == LFS_ERR_NOTEMPTY);
+            }
+
+            lfs_stat(&lfs, full_path, &info) => LFS_ERR_NOENT;
+        }
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
+# non-reentrant testing for orphans, this is the same as reentrant
+# testing, but we test way more states than we could under powerloss
+[cases.test_orphans_nonreentrant]
+# TODO fix this case, caused by non-DAG trees
+# NOTE the second condition is required
+if = '!(DEPTH == 3 && CACHE_SIZE != 64) && 2*FILES < BLOCK_COUNT'
+defines = [
+    {FILES=6,   DEPTH=1, CYCLES=2000},
+    {FILES=26,  DEPTH=1, CYCLES=2000},
+    {FILES=3,   DEPTH=3, CYCLES=2000},
+]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    uint32_t prng = 1;
+    const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+    for (unsigned i = 0; i < CYCLES; i++) {
+        // create random path
+        char full_path[256];
+        for (unsigned d = 0; d < DEPTH; d++) {
+            sprintf(&full_path[2*d], "/%c", alpha[TEST_PRNG(&prng) % FILES]);
+        }
+
+        // if it does not exist, we create it, else we destroy
+        struct lfs_info info;
+        int res = lfs_stat(&lfs, full_path, &info);
+        if (res == LFS_ERR_NOENT) {
+            // create each directory in turn, ignore if dir already exists
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                int err = lfs_mkdir(&lfs, path);
+                assert(!err || err == LFS_ERR_EXIST);
+            }
+
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                lfs_stat(&lfs, path, &info) => 0;
+                assert(strcmp(info.name, &path[2*d+1]) == 0);
+                assert(info.type == LFS_TYPE_DIR);
+            }
+        } else {
+            // is valid dir?
+            assert(strcmp(info.name, &full_path[2*(DEPTH-1)+1]) == 0);
+            assert(info.type == LFS_TYPE_DIR);
+
+            // try to delete path in reverse order, ignore if dir is not empty
+            for (int d = DEPTH-1; d >= 0; d--) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                int err = lfs_remove(&lfs, path);
                 assert(!err || err == LFS_ERR_NOTEMPTY);
             }
 

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -1846,6 +1846,198 @@ code = '''
 '''
 
 # dot dot dot path tests
+[cases.test_paths_dot_dotdots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "no") => 0;
+    lfs_mkdir(&lfs, "no/no") => 0;
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_mkdir(&lfs, "coffee/no") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/drip") => 0;
+        lfs_mkdir(&lfs, "/no/./../coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "/coffee/no/./../turkish") => 0;
+        lfs_mkdir(&lfs, "/no/no/./.././../coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "/no/no/./.././../coffee/no/./../vietnamese") => 0;
+        lfs_mkdir(&lfs, "/no/no/./.././../no/no/./.././../coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "/no/no/./.././../no/no/./.././../coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/./.././../coffee/no/./../coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/./.././../coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/no/./../tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/./../coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/./../coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/no/./../turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../coffee/tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../coffee/no/./../vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../no/no/./.././../coffee/thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/./../coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/no/./../turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../coffee/tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../coffee/no/./../vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/./.././../no/no/./.././../coffee/thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/no/./.././../no/no/./.././../coffee/drip",
+            "/espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/no/./.././../coffee/no/./../coldbrew",
+            "/no/./../espresso/americano") => 0;
+    lfs_rename(&lfs,
+            "/no/no/./.././../coffee/turkish",
+            "/espresso/no/./../macchiato") => 0;
+    lfs_rename(&lfs,
+            "/coffee/no/./../tubruk",
+            "/no/no/./.././../espresso/latte") => 0;
+    lfs_rename(&lfs,
+            "/no/./../coffee/vietnamese",
+            "/no/no/./.././../espresso/no/./../cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/thai",
+            "/no/no/./.././../no/no/./.././../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/no/./.././../no/no/./.././../espresso/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/./.././../espresso/no/./../americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/./.././../espresso/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/no/./../latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/./../espresso/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "/no/no/./.././../no/no/./.././../coffee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/./.././../coffee/no/./../coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/./.././../coffee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/no/./../tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/./../coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/espresso") => 0;
+    lfs_remove(&lfs, "/no/./../espresso/americano") => 0;
+    lfs_remove(&lfs, "/espresso/no/./../macchiato") => 0;
+    lfs_remove(&lfs, "/no/no/./.././../espresso/latte") => 0;
+    lfs_remove(&lfs, "/no/no/./.././../espresso/no/./../cappuccino") => 0;
+    lfs_remove(&lfs, "/no/no/./.././../no/no/./.././../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/no/./.././../no/no/./.././../espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/./.././../espresso/no/./../americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/./.././../espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/no/./../latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/./../espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# dot dot dot path tests
 [cases.test_paths_dotdotdots]
 defines.DIR = [false, true]
 code = '''

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -764,17 +764,17 @@ code = '''
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/drip/",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/coldbrew//",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/turkish///",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/tubruk////",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/thai//////",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
 
         // still create so we have something to test
         lfs_file_open(&lfs, &file, "coffee/drip",
@@ -3972,30 +3972,30 @@ code = '''
             LFS_O_RDONLY) => LFS_ERR_NOENT;
 
     lfs_file_open(&lfs, &file, "coffee/_rip/",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/c_ldbrew//",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/tu_kish///",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/tub_uk////",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/_vietnamese/////",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/thai_//////",
-            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
 
     lfs_file_open(&lfs, &file, "coffee/_rip/",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/c_ldbrew//",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/tu_kish///",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/tub_uk////",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/_vietnamese/////",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     lfs_file_open(&lfs, &file, "coffee/thai_//////",
-            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
 
     // dir open paths, only works on dirs!
     lfs_dir_t dir;

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -1,237 +1,2207 @@
 
 # simple path test
-[cases.test_paths_normal]
+[cases.test_paths_simple]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
 
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "/tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
 
-    lfs_mkdir(&lfs, "/milk") => 0;
-    lfs_stat(&lfs, "/milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
-    lfs_stat(&lfs, "milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/drip",
+            "espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "espresso/americano") => 0;
+    lfs_rename(&lfs,
+            "coffee/turkish",
+            "espresso/macchiato") => 0;
+    lfs_rename(&lfs,
+            "coffee/tubruk",
+            "espresso/latte") => 0;
+    lfs_rename(&lfs,
+            "coffee/vietnamese",
+            "espresso/cappuccino") => 0;
+    lfs_rename(&lfs,
+            "coffee/thai",
+            "espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "coffee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "espresso/espresso") => 0;
+    lfs_remove(&lfs, "espresso/americano") => 0;
+    lfs_remove(&lfs, "espresso/macchiato") => 0;
+    lfs_remove(&lfs, "espresso/latte") => 0;
+    lfs_remove(&lfs, "espresso/cappuccino") => 0;
+    lfs_remove(&lfs, "espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# absolute path test
+#
+# littlefs does not provide cd, so these are the same as relative paths
+[cases.test_paths_absolute]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/drip") => 0;
+        lfs_mkdir(&lfs, "/coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "/coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "/coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "/coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "/coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "/coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/drip",
+            "/espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "/espresso/americano") => 0;
+    lfs_rename(&lfs,
+            "/coffee/turkish",
+            "espresso/macchiato") => 0;
+    lfs_rename(&lfs,
+            "/coffee/tubruk",
+            "espresso/latte") => 0;
+    lfs_rename(&lfs,
+            "/coffee/vietnamese",
+            "/espresso/cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/thai",
+            "/espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "/coffee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/espresso") => 0;
+    lfs_remove(&lfs, "/espresso/americano") => 0;
+    lfs_remove(&lfs, "/espresso/macchiato") => 0;
+    lfs_remove(&lfs, "/espresso/latte") => 0;
+    lfs_remove(&lfs, "/espresso/cappuccino") => 0;
+    lfs_remove(&lfs, "/espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
 # redundant slashes
 [cases.test_paths_redundant_slashes]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
 
-    struct lfs_info info;
-    lfs_stat(&lfs, "/tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "//tea//hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "///tea///hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-
-    lfs_mkdir(&lfs, "////milk") => 0;
-    lfs_stat(&lfs, "////milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
-    lfs_stat(&lfs, "milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
-    lfs_unmount(&lfs) => 0;
-'''
-
-# dot path test
-[cases.test_paths_dot]
-code = '''
-    lfs_t lfs;
-    lfs_format(&lfs, cfg) => 0;
-    lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
-
-    struct lfs_info info;
-    lfs_stat(&lfs, "./tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "/./tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "/././tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "/./tea/./hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-
-    lfs_mkdir(&lfs, "/./milk") => 0;
-    lfs_stat(&lfs, "/./milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
-    lfs_stat(&lfs, "milk", &info) => 0;
-    assert(strcmp(info.name, "milk") == 0);
-    lfs_unmount(&lfs) => 0;
-'''
-
-# dot dot path test
-[cases.test_paths_dot_dot]
-code = '''
-    lfs_t lfs;
-    lfs_format(&lfs, cfg) => 0;
-    lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
+    // create paths
     lfs_mkdir(&lfs, "coffee") => 0;
-    lfs_mkdir(&lfs, "coffee/hotcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/warmcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/coldcoffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/drip") => 0;
+        lfs_mkdir(&lfs, "//coffee//coldbrew") => 0;
+        lfs_mkdir(&lfs, "///coffee///turkish") => 0;
+        lfs_mkdir(&lfs, "////coffee////tubruk") => 0;
+        lfs_mkdir(&lfs, "/////coffee/////vietnamese") => 0;
+        lfs_mkdir(&lfs, "//////coffee//////thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
 
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "coffee/../tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "tea/coldtea/../hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "coffee/coldcoffee/../../tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "coffee/../coffee/../tea/hottea", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
+    lfs_stat(&lfs, "//////coffee//////drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/////coffee/////coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "////coffee////turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "///coffee///tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "//coffee//vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
 
-    lfs_mkdir(&lfs, "coffee/../milk") => 0;
-    lfs_stat(&lfs, "coffee/../milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
-    lfs_stat(&lfs, "milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "//coffee//coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "///coffee///turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "////coffee////tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/////coffee/////vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "//////coffee//////thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "//coffee//coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "///coffee///turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "////coffee////tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/////coffee/////vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "//////coffee//////thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "//////coffee//////drip",
+            "/espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "/////coffee/////coldbrew",
+            "//espresso//americano") => 0;
+    lfs_rename(&lfs,
+            "////coffee////turkish",
+            "///espresso///macchiato") => 0;
+    lfs_rename(&lfs,
+            "///coffee///tubruk",
+            "////espresso////latte") => 0;
+    lfs_rename(&lfs,
+            "//coffee//vietnamese",
+            "/////espresso/////cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/thai",
+            "//////espresso//////mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "//////espresso//////espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/////espresso/////americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "////espresso////macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "///espresso///latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "//espresso//cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "//////coffee//////drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/////coffee/////coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "////coffee////turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "///coffee///tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "//coffee//vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/espresso") => 0;
+    lfs_remove(&lfs, "//espresso//americano") => 0;
+    lfs_remove(&lfs, "///espresso///macchiato") => 0;
+    lfs_remove(&lfs, "////espresso////latte") => 0;
+    lfs_remove(&lfs, "/////espresso/////cappuccino") => 0;
+    lfs_remove(&lfs, "//////espresso//////mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "//////espresso//////espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/////espresso/////americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "////espresso////macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "///espresso///latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "//espresso//cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/mocha", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# trailing dot path test
-[cases.test_paths_trailing_dot]
+# TODO test trailing slashes
+
+# dot path tests
+[cases.test_paths_dots]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
 
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/drip") => 0;
+        lfs_mkdir(&lfs, "/./coffee/./coldbrew") => 0;
+        lfs_mkdir(&lfs, "/././coffee/././turkish") => 0;
+        lfs_mkdir(&lfs, "/./././coffee/./././tubruk") => 0;
+        lfs_mkdir(&lfs, "/././././coffee/././././vietnamese") => 0;
+        lfs_mkdir(&lfs, "/./././././coffee/./././././thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "tea/hottea/", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "tea/hottea/.", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "tea/hottea/./.", &info) => 0;
-    assert(strcmp(info.name, "hottea") == 0);
-    lfs_stat(&lfs, "tea/hottea/..", &info) => 0;
-    assert(strcmp(info.name, "tea") == 0);
-    lfs_stat(&lfs, "tea/hottea/../.", &info) => 0;
-    assert(strcmp(info.name, "tea") == 0);
+    lfs_stat(&lfs, "/./././././coffee/./././././drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/././././coffee/././././coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/./././coffee/./././turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/././coffee/././tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/./coffee/./vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/./coffee/./coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/././coffee/././turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/./././coffee/./././tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/././././coffee/././././vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/./././././coffee/./././././thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/./coffee/./coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/././coffee/././turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/./././coffee/./././tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/././././coffee/././././vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/./././././coffee/./././././thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "/./././././coffee/./././././drip",
+            "/espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "/././././coffee/././././coldbrew",
+            "/./espresso/./americano") => 0;
+    lfs_rename(&lfs,
+            "/./././coffee/./././turkish",
+            "/././espresso/././macchiato") => 0;
+    lfs_rename(&lfs,
+            "/././coffee/././tubruk",
+            "/./././espresso/./././latte") => 0;
+    lfs_rename(&lfs,
+            "/./coffee/./vietnamese",
+            "/././././espresso/././././cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/thai",
+            "/./././././espresso/./././././mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/./././././espresso/./././././espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/././././espresso/././././americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/./././espresso/./././macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/././espresso/././latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/./espresso/./cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "/./././././coffee/./././././drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/././././coffee/././././coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/./././coffee/./././turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/././coffee/././tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/./coffee/./vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/espresso") => 0;
+    lfs_remove(&lfs, "/./espresso/./americano") => 0;
+    lfs_remove(&lfs, "/././espresso/././macchiato") => 0;
+    lfs_remove(&lfs, "/./././espresso/./././latte") => 0;
+    lfs_remove(&lfs, "/././././espresso/././././cappuccino") => 0;
+    lfs_remove(&lfs, "/./././././espresso/./././././mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/./././././espresso/./././././espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/././././espresso/././././americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/./././espresso/./././macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/././espresso/././latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/./espresso/./cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# TODO test trailing dots
+
+# dot dot path tests
+[cases.test_paths_dotdots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "no") => 0;
+    lfs_mkdir(&lfs, "no/no") => 0;
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_mkdir(&lfs, "coffee/no") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/drip") => 0;
+        lfs_mkdir(&lfs, "/no/../coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "/coffee/no/../turkish") => 0;
+        lfs_mkdir(&lfs, "/no/no/../../coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "/no/no/../../coffee/no/../vietnamese") => 0;
+        lfs_mkdir(&lfs, "/no/no/../../no/no/../../coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "/no/no/../../no/no/../../coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/../../coffee/no/../coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/../../coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/no/../tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/../coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/no/../turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../coffee/tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../coffee/no/../vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../no/no/../../coffee/thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/../coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/no/../turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../coffee/tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../coffee/no/../vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/no/../../no/no/../../coffee/thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/no/../../no/no/../../coffee/drip",
+            "/espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/no/../../coffee/no/../coldbrew",
+            "/no/../espresso/americano") => 0;
+    lfs_rename(&lfs,
+            "/no/no/../../coffee/turkish",
+            "/espresso/no/../macchiato") => 0;
+    lfs_rename(&lfs,
+            "/coffee/no/../tubruk",
+            "/no/no/../../espresso/latte") => 0;
+    lfs_rename(&lfs,
+            "/no/../coffee/vietnamese",
+            "/no/no/../../espresso/no/../cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/thai",
+            "/no/no/../../no/no/../../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/no/../../no/no/../../espresso/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/../../espresso/no/../americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/no/../../espresso/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/no/../latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../espresso/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "/no/no/../../no/no/../../coffee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/../../coffee/no/../coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/../../coffee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/no/../tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/espresso") => 0;
+    lfs_remove(&lfs, "/no/../espresso/americano") => 0;
+    lfs_remove(&lfs, "/espresso/no/../macchiato") => 0;
+    lfs_remove(&lfs, "/no/no/../../espresso/latte") => 0;
+    lfs_remove(&lfs, "/no/no/../../espresso/no/../cappuccino") => 0;
+    lfs_remove(&lfs, "/no/no/../../no/no/../../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/no/../../no/no/../../espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/../../espresso/no/../americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/no/../../espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/no/../latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# TODO test trailing dotdots
+
+# dot dot dot path tests
+[cases.test_paths_dotdotdots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_mkdir(&lfs, "coffee/...") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/.../drip") => 0;
+        lfs_mkdir(&lfs, "/coffee/.../coldbrew") => 0;
+        lfs_mkdir(&lfs, "/coffee/.../turkish") => 0;
+        lfs_mkdir(&lfs, "/coffee/.../tubruk") => 0;
+        lfs_mkdir(&lfs, "/coffee/.../vietnamese") => 0;
+        lfs_mkdir(&lfs, "/coffee/.../thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "/coffee/.../drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.../coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.../turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.../tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.../vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.../thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.../thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_mkdir(&lfs, "espresso/...") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../drip",
+            "/espresso/.../espresso") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../coldbrew",
+            "/espresso/.../americano") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../turkish",
+            "/espresso/.../macchiato") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../tubruk",
+            "/espresso/.../latte") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../vietnamese",
+            "/espresso/.../cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.../thai",
+            "/espresso/.../mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/.../espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.../americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.../macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.../latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.../cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.../mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "coffee/.../drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.../coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.../turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.../tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.../vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.../thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/.../espresso") => 0;
+    lfs_remove(&lfs, "/espresso/.../americano") => 0;
+    lfs_remove(&lfs, "/espresso/.../macchiato") => 0;
+    lfs_remove(&lfs, "/espresso/.../latte") => 0;
+    lfs_remove(&lfs, "/espresso/.../cappuccino") => 0;
+    lfs_remove(&lfs, "/espresso/.../mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/.../espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.../americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.../macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.../latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.../cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.../mocha", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
 # leading dot path test
-[cases.test_paths_leading_dot]
+[cases.test_paths_leading_dots]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, ".milk") => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/coffee/.drip") => 0;
+        lfs_mkdir(&lfs, "/coffee/..coldbrew") => 0;
+        lfs_mkdir(&lfs, "/coffee/...turkish") => 0;
+        lfs_mkdir(&lfs, "/coffee/....tubruk") => 0;
+        lfs_mkdir(&lfs, "/coffee/.....vietnamese") => 0;
+        lfs_mkdir(&lfs, "/coffee/......thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, ".milk", &info) => 0;
-    strcmp(info.name, ".milk") => 0;
-    lfs_stat(&lfs, "tea/.././.milk", &info) => 0;
-    strcmp(info.name, ".milk") => 0;
+    lfs_stat(&lfs, "/coffee/.drip", &info) => 0;
+    assert(strcmp(info.name, ".drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/..coldbrew", &info) => 0;
+    assert(strcmp(info.name, "..coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/...turkish", &info) => 0;
+    assert(strcmp(info.name, "...turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/....tubruk", &info) => 0;
+    assert(strcmp(info.name, "....tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/.....vietnamese", &info) => 0;
+    assert(strcmp(info.name, ".....vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/coffee/......thai", &info) => 0;
+    assert(strcmp(info.name, "......thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/.drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/..coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/...turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/....tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/.....vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/coffee/......thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/coffee/.drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/..coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/...turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/....tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/.....vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/coffee/......thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.drip",
+            "/espresso/.espresso") => 0;
+    lfs_rename(&lfs,
+            "/coffee/..coldbrew",
+            "/espresso/..americano") => 0;
+    lfs_rename(&lfs,
+            "/coffee/...turkish",
+            "/espresso/...macchiato") => 0;
+    lfs_rename(&lfs,
+            "/coffee/....tubruk",
+            "/espresso/....latte") => 0;
+    lfs_rename(&lfs,
+            "/coffee/.....vietnamese",
+            "/espresso/.....cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/coffee/......thai",
+            "/espresso/......mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/.espresso", &info) => 0;
+    assert(strcmp(info.name, ".espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/..americano", &info) => 0;
+    assert(strcmp(info.name, "..americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/...macchiato", &info) => 0;
+    assert(strcmp(info.name, "...macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/....latte", &info) => 0;
+    assert(strcmp(info.name, "....latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/.....cappuccino", &info) => 0;
+    assert(strcmp(info.name, ".....cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/espresso/......mocha", &info) => 0;
+    assert(strcmp(info.name, "......mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "coffee/.drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/..coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/...turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/....tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/.....vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/......thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/espresso/.espresso") => 0;
+    lfs_remove(&lfs, "/espresso/..americano") => 0;
+    lfs_remove(&lfs, "/espresso/...macchiato") => 0;
+    lfs_remove(&lfs, "/espresso/....latte") => 0;
+    lfs_remove(&lfs, "/espresso/.....cappuccino") => 0;
+    lfs_remove(&lfs, "/espresso/......mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/espresso/.espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/..americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/...macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/....latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/.....cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/espresso/......mocha", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
 # root dot dot path test
-[cases.test_paths_root_dot_dot]
+[cases.test_paths_root_dotdots]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "tea") => 0;
-    lfs_mkdir(&lfs, "tea/hottea") => 0;
-    lfs_mkdir(&lfs, "tea/warmtea") => 0;
-    lfs_mkdir(&lfs, "tea/coldtea") => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "no") => 0;
     lfs_mkdir(&lfs, "coffee") => 0;
-    lfs_mkdir(&lfs, "coffee/hotcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/warmcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/coldcoffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "/../coffee/drip") => 0;
+        lfs_mkdir(&lfs, "/../../coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "/../../../coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "/no/../../coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "/no/../../../coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "/no/../../../../coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/../coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
 
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "coffee/../../../../../../tea/hottea", &info) => 0;
-    strcmp(info.name, "hottea") => 0;
+    lfs_stat(&lfs, "/no/../../../../coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../../../coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../../coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../../../coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../../coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
 
-    lfs_mkdir(&lfs, "coffee/../../../../../../milk") => 0;
-    lfs_stat(&lfs, "coffee/../../../../../../milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
-    lfs_stat(&lfs, "milk", &info) => 0;
-    strcmp(info.name, "milk") => 0;
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/../coffee/drip",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/../coffee/drip",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/../coffee/drip") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/../../coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/../../../coffee/turkish") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/../../coffee/tubruk") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/../../../coffee/vietnamese") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "/no/../../../../coffee/thai") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "/../coffee/drip") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/../../coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/../../../coffee/turkish") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/../coffee/tubruk") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/../../coffee/vietnamese") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "/no/../../../coffee/thai") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/../../../../coffee/drip",
+            "/../espresso/espresso") => 0;
+    lfs_rename(&lfs,
+            "/no/../../../coffee/coldbrew",
+            "/../../espresso/americano") => 0;
+    lfs_rename(&lfs,
+            "/no/../../coffee/turkish",
+            "/../../../espresso/macchiato") => 0;
+    lfs_rename(&lfs,
+            "/../../../coffee/tubruk",
+            "/no/../../espresso/latte") => 0;
+    lfs_rename(&lfs,
+            "/../../coffee/vietnamese",
+            "/no/../../../espresso/cappuccino") => 0;
+    lfs_rename(&lfs,
+            "/../coffee/thai",
+            "/no/../../../../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/../../../../espresso/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../../../espresso/americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../../espresso/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../../../espresso/latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../../espresso/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/../espresso/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "/no/../../../../coffee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../../../coffee/coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../../coffee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../../../coffee/tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../../coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../coffee/thai", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "/../espresso/espresso") => 0;
+    lfs_remove(&lfs, "/../../espresso/americano") => 0;
+    lfs_remove(&lfs, "/../../../espresso/macchiato") => 0;
+    lfs_remove(&lfs, "/no/../../espresso/latte") => 0;
+    lfs_remove(&lfs, "/no/../../../espresso/cappuccino") => 0;
+    lfs_remove(&lfs, "/no/../../../../espresso/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "/no/../../../../espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../../../espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/no/../../espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../../../espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../../espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "/../espresso/mocha", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# invalid path tests
-[cases.test_paths_invalid]
+# trailing noent tests
+[cases.test_paths_noent]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
-    lfs_format(&lfs, cfg);
+    lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "dirt", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "dirt/ground", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "dirt/ground/earth", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/_rip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/c_ldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tu_kish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tub_uk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/_vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/thai_", &info) => LFS_ERR_NOENT;
 
-    lfs_remove(&lfs, "dirt") => LFS_ERR_NOENT;
-    lfs_remove(&lfs, "dirt/ground") => LFS_ERR_NOENT;
-    lfs_remove(&lfs, "dirt/ground/earth") => LFS_ERR_NOENT;
-
-    lfs_mkdir(&lfs, "dirt/ground") => LFS_ERR_NOENT;
+    // file open paths, only works on files!
     lfs_file_t file;
-    lfs_file_open(&lfs, &file, "dirt/ground", LFS_O_WRONLY | LFS_O_CREAT)
-            => LFS_ERR_NOENT;
-    lfs_mkdir(&lfs, "dirt/ground/earth") => LFS_ERR_NOENT;
-    lfs_file_open(&lfs, &file, "dirt/ground/earth", LFS_O_WRONLY | LFS_O_CREAT)
-            => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_rip",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/thai_",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "coffee/_rip") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/c_ldbrew") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tu_kish") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tub_uk") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/_vietnamese") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/thai_") => LFS_ERR_NOENT;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/_rip",
+            "espresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew",
+            "espresso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish",
+            "espresso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk",
+            "espresso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese",
+            "espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_",
+            "espresso/mocha") => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "coffee/_rip") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/c_ldbrew") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tu_kish") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tub_uk") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/_vietnamese") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/thai_") => LFS_ERR_NOENT;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# parent noent tests
+[cases.test_paths_noent_parent]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "_offee/drip") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "c_ffee/coldbrew") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "co_fee/turkish") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "cof_ee/tubruk") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "_coffee/vietnamese") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee_/thai") => LFS_ERR_NOENT;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "_offee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "c_ffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "co_fee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "cof_ee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "_coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee_/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    }
+
+    // ok, actually create paths
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "_offee/drip", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c_ffee/coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "co_fee/turkish", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "cof_ee/tubruk", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "_coffee/vietnamese", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee_/thai", &info) => LFS_ERR_NOENT;
+
+    // file open paths, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "_offee/drip",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "c_ffee/coldbrew",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "co_fee/turkish",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "cof_ee/tubruk",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "_coffee/vietnamese",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee_/thai",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "_offee/drip") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "c_ffee/coldbrew") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "co_fee/turkish") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "cof_ee/tubruk") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "_coffee/vietnamese") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee_/thai") => LFS_ERR_NOENT;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "_offee/drip",
+            "espresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "c_ffee/coldbrew",
+            "espresso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "co_fee/turkish",
+            "espresso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "cof_ee/tubruk",
+            "espresso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "_coffee/vietnamese",
+            "espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee_/thai",
+            "espresso/mocha") => LFS_ERR_NOENT;
+
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/drip",
+            "_spresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "e_presso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/turkish",
+            "es_resso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tubruk",
+            "esp_esso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/vietnamese",
+            "_espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai",
+            "espresso_/mocha") => LFS_ERR_NOENT;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "_offee/drip",
+            "_spresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "c_ffee/coldbrew",
+            "e_presso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "co_fee/turkish",
+            "es_resso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "cof_ee/tubruk",
+            "esp_esso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "_coffee/vietnamese",
+            "_espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee_/thai",
+            "espresso_/mocha") => LFS_ERR_NOENT;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "_offee/drip",
+            "_offee/drip") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "c_ffee/coldbrew",
+            "c_ffee/coldbrew") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "co_fee/turkish",
+            "co_fee/turkish") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "cof_ee/tubruk",
+            "cof_ee/tubruk") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "_coffee/vietnamese",
+            "_coffee/vietnamese") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee_/thai",
+            "coffee_/thai") => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "_offee/drip") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "c_ffee/coldbrew") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "co_fee/turkish") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "cof_ee/tubruk") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "_coffee/vietnamese") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee_/thai") => LFS_ERR_NOENT;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# parent notdir tests
+[cases.test_paths_notdir_parent]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "drip",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_open(&lfs, &file, "coldbrew",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_open(&lfs, &file, "turkish",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_open(&lfs, &file, "tubruk",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_open(&lfs, &file, "vietnamese",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_file_open(&lfs, &file, "thai",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    lfs_file_close(&lfs, &file) => 0;
+
+    if (DIR) {
+        lfs_mkdir(&lfs, "drip/coffee") => LFS_ERR_NOTDIR;
+        lfs_mkdir(&lfs, "coldbrew/coffee") => LFS_ERR_NOTDIR;
+        lfs_mkdir(&lfs, "turkish/coffee") => LFS_ERR_NOTDIR;
+        lfs_mkdir(&lfs, "tubruk/coffee") => LFS_ERR_NOTDIR;
+        lfs_mkdir(&lfs, "vietnamese/coffee") => LFS_ERR_NOTDIR;
+        lfs_mkdir(&lfs, "thai/coffee") => LFS_ERR_NOTDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "drip/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coldbrew/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "turkish/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "tubruk/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "vietnamese/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "thai/coffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "drip/coffee", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "coldbrew/coffee", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "turkish/coffee", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "tubruk/coffee", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "vietnamese/coffee", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "thai/coffee", &info) => LFS_ERR_NOTDIR;
+
+    // file open paths, only works on files!
+    lfs_file_open(&lfs, &file, "drip/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "coldbrew/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "turkish/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "tubruk/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "vietnamese/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "thai/coffee",
+            LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "drip/coffee") => LFS_ERR_NOTDIR;
+    lfs_dir_open(&lfs, &dir, "coldbrew/coffee") => LFS_ERR_NOTDIR;
+    lfs_dir_open(&lfs, &dir, "turkish/coffee") => LFS_ERR_NOTDIR;
+    lfs_dir_open(&lfs, &dir, "tubruk/coffee") => LFS_ERR_NOTDIR;
+    lfs_dir_open(&lfs, &dir, "vietnamese/coffee") => LFS_ERR_NOTDIR;
+    lfs_dir_open(&lfs, &dir, "thai/coffee") => LFS_ERR_NOTDIR;
+
+    // make some normal paths so we have something to rename
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "drip/coffee",
+            "espresso/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coldbrew/coffee",
+            "espresso/americano") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "turkish/coffee",
+            "espresso/macchiato") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "tubruk/coffee",
+            "espresso/latte") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "vietnamese/coffee",
+            "espresso/cappuccino") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "thai/coffee",
+            "espresso/mocha") => LFS_ERR_NOTDIR;
+
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/drip",
+            "drip/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "coldbrew/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coffee/turkish",
+            "turkish/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coffee/tubruk",
+            "tubruk/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coffee/vietnamese",
+            "vietnamese/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coffee/thai",
+            "thai/espresso") => LFS_ERR_NOTDIR;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "drip/coffee",
+            "drip/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coldbrew/coffee",
+            "coldbrew/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "turkish/coffee",
+            "turkish/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "tubruk/coffee",
+            "tubruk/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "vietnamese/coffee",
+            "vietnamese/espresso") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "thai/coffee",
+            "thai/espresso") => LFS_ERR_NOTDIR;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "drip/coffee",
+            "drip/coffee") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "coldbrew/coffee",
+            "coldbrew/coffee") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "turkish/coffee",
+            "turkish/coffee") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "tubruk/coffee",
+            "tubruk/coffee") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "vietnamese/coffee",
+            "vietnamese/coffee") => LFS_ERR_NOTDIR;
+    lfs_rename(&lfs,
+            "thai/coffee",
+            "thai/coffee") => LFS_ERR_NOTDIR;
+
+    // remove paths
+    lfs_stat(&lfs, "drip/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "coldbrew/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "turkish/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "tubruk/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "vietnamese/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "thai/espresso", &info) => LFS_ERR_NOTDIR;
+
+    // stat paths
+    lfs_stat(&lfs, "drip/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "coldbrew/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "turkish/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "tubruk/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "vietnamese/espresso", &info) => LFS_ERR_NOTDIR;
+    lfs_stat(&lfs, "thai/espresso", &info) => LFS_ERR_NOTDIR;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
     lfs_unmount(&lfs) => 0;
 '''
 
 # root operations
 [cases.test_paths_root]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
     struct lfs_info info;
+
+    // create root, this should error
+    if (DIR) {
+        lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    }
+
+    // stat root
     lfs_stat(&lfs, "/", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
 
-    lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
+    // file open root, only works on files!
     lfs_file_t file;
-    lfs_file_open(&lfs, &file, "/", LFS_O_WRONLY | LFS_O_CREAT)
-            => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
 
+    // dir open root, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "/") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+
+    // rename root, this should error
+    lfs_rename(&lfs, "/", "coffee") => LFS_ERR_INVAL;
+
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_rename(&lfs, "coffee", "/") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee") => 0;
+
+    lfs_rename(&lfs, "/", "/") => LFS_ERR_INVAL;
+
+    // stat root
+    lfs_stat(&lfs, "/", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
+    // remove root, this should error
     lfs_remove(&lfs, "/") => LFS_ERR_INVAL;
+
+    // stat root
+    lfs_stat(&lfs, "/", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# root representations
-[cases.test_paths_root_reprs]
+# other root representations
+[cases.test_paths_root_aliases]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
     struct lfs_info info;
+
+    // create root, this should error
+    if (DIR) {
+        lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, ".") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "./") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "/.") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "//") => LFS_ERR_EXIST;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "/",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, ".",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "..",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "./",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "//",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    }
+
+    // stat root
     lfs_stat(&lfs, "/", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
@@ -244,93 +2214,2127 @@ code = '''
     lfs_stat(&lfs, "..", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "./", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "/.", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, "//", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
+    // file open root, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, ".",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "./",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "/.",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "//",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+    // dir open root, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "/") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, ".") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "./") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "/.") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "//") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+
+    // rename root, this should error
+    lfs_rename(&lfs, "/", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, ".", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "..", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "./", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "/.", "coffee") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "//", "coffee") => LFS_ERR_INVAL;
+
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_rename(&lfs, "coffee", "/") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", "") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", ".") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", "..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", "./") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", "/.") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "coffee", "//") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee") => 0;
+
+    lfs_rename(&lfs, "/", "/") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "", "") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, ".", ".") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "..", "..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "./", "./") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "/.", "/.") => LFS_ERR_INVAL;
+    lfs_rename(&lfs, "//", "//") => LFS_ERR_INVAL;
+
+    // stat root
+    lfs_stat(&lfs, "/", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, ".", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "..", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, "./", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "/.", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "//", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
+    // remove root, this should error
+    lfs_remove(&lfs, "/") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, ".") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "./") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/.") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "//") => LFS_ERR_INVAL;
+
+    // stat root
+    lfs_stat(&lfs, "/", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, ".", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "./", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "/.", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "//", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# superblock conflict test
-[cases.test_paths_superblock_conflict]
+# superblock magic shouldn't appear as a file
+[cases.test_paths_magic_noent]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
+
+    // stat littlefs, which shouldn't exist
     struct lfs_info info;
     lfs_stat(&lfs, "littlefs", &info) => LFS_ERR_NOENT;
+
+    // dir open littlefs, which shouldn't exist
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "littlefs") => LFS_ERR_NOENT;
+
+    // rename littlefs, which shouldn't exist
+    lfs_rename(&lfs, "littlefs", "coffee") => LFS_ERR_NOENT;
+
+    // remove littlefs, which shouldn't exist
     lfs_remove(&lfs, "littlefs") => LFS_ERR_NOENT;
 
-    lfs_mkdir(&lfs, "littlefs") => 0;
+    // stat littlefs, which shouldn't exist
+    lfs_stat(&lfs, "coffee", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "littlefs", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# superblock magic shouldn't conflict with files, that would be silly
+[cases.test_paths_magic_conflict]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create littlefs
+    if (DIR) {
+        lfs_mkdir(&lfs, "littlefs") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat littlefs
+    struct lfs_info info;
     lfs_stat(&lfs, "littlefs", &info) => 0;
     assert(strcmp(info.name, "littlefs") == 0);
-    assert(info.type == LFS_TYPE_DIR);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open littlefs, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open littlefs, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "littlefs") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "littlefs") => LFS_ERR_NOTDIR;
+    }
+
+    // rename littlefs
+    lfs_rename(&lfs, "littlefs", "coffee") => 0;
+    lfs_rename(&lfs, "coffee", "littlefs") => 0;
+
+    // stat littlefs
+    lfs_stat(&lfs, "littlefs", &info) => 0;
+    assert(strcmp(info.name, "littlefs") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "coffee", &info) => LFS_ERR_NOENT;
+
+    // remove littlefs
     lfs_remove(&lfs, "littlefs") => 0;
+
+    // stat littlefs
     lfs_stat(&lfs, "littlefs", &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# max path test
-[cases.test_paths_max]
+# test name too long
+[cases.test_paths_nametoolong]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "coffee") => 0;
-    lfs_mkdir(&lfs, "coffee/hotcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/warmcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/coldcoffee") => 0;
 
+    char a_name[512];
+    memset(a_name, 'a', LFS_NAME_MAX+1);
+    a_name[LFS_NAME_MAX+1] = '\0';
+
+    // create names that are too long, should error
     char path[1024];
-    memset(path, 'w', LFS_NAME_MAX+1);
-    path[LFS_NAME_MAX+1] = '\0';
-    lfs_mkdir(&lfs, path) => LFS_ERR_NAMETOOLONG;
-    lfs_file_t file;
-    lfs_file_open(&lfs, &file, path, LFS_O_WRONLY | LFS_O_CREAT)
-            => LFS_ERR_NAMETOOLONG;
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        sprintf(path, "coffee/%s", a_name);
+        lfs_mkdir(&lfs, path) => LFS_ERR_NAMETOOLONG;
+    } else {
+        lfs_file_t file;
+        sprintf(path, "coffee/%s", a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NAMETOOLONG;
+    }
 
-    memcpy(path, "coffee/", strlen("coffee/"));
-    memset(path+strlen("coffee/"), 'w', LFS_NAME_MAX+1);
-    path[strlen("coffee/")+LFS_NAME_MAX+1] = '\0';
-    lfs_mkdir(&lfs, path) => LFS_ERR_NAMETOOLONG;
-    lfs_file_open(&lfs, &file, path, LFS_O_WRONLY | LFS_O_CREAT)
-            => LFS_ERR_NAMETOOLONG;
+    // stat paths
+    struct lfs_info info;
+    sprintf(path, "coffee/%s", a_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+
+    // file open paths, only works on files!
+    lfs_file_t file;
+    sprintf(path, "coffee/%s", a_name);
+    lfs_file_open(&lfs, &file, path,
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    sprintf(path, "coffee/%s", a_name);
+    lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOENT;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    sprintf(path, "coffee/%s", a_name);
+    lfs_rename(&lfs, path, "espresso/espresso") => LFS_ERR_NOENT;
+
+    // renaming with too long a destination is tricky!
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    sprintf(path, "espresso/%s", a_name);
+    lfs_rename(&lfs, "coffee/drip", path) => LFS_ERR_NAMETOOLONG;
+
+    // stat paths
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    sprintf(path, "espresso/%s", a_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    sprintf(path, "espresso/%s", a_name);
+    lfs_remove(&lfs, path) => LFS_ERR_NOENT;
+
+    // stat paths
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    sprintf(path, "espresso/%s", a_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
-# really big path test
-[cases.test_paths_really_big]
+# test name really long but not too long
+[cases.test_paths_namejustlongenough]
+defines.DIR = [false, true]
 code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_mkdir(&lfs, "coffee") => 0;
-    lfs_mkdir(&lfs, "coffee/hotcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/warmcoffee") => 0;
-    lfs_mkdir(&lfs, "coffee/coldcoffee") => 0;
 
+    char a_name[512];
+    memset(a_name, 'a', LFS_NAME_MAX);
+    a_name[LFS_NAME_MAX] = '\0';
+    char b_name[512];
+    memset(b_name, 'b', LFS_NAME_MAX);
+    b_name[LFS_NAME_MAX] = '\0';
+    char c_name[512];
+    memset(c_name, 'c', LFS_NAME_MAX);
+    c_name[LFS_NAME_MAX] = '\0';
+    char d_name[512];
+    memset(d_name, 'd', LFS_NAME_MAX);
+    d_name[LFS_NAME_MAX] = '\0';
+    char e_name[512];
+    memset(e_name, 'e', LFS_NAME_MAX);
+    e_name[LFS_NAME_MAX] = '\0';
+    char f_name[512];
+    memset(f_name, 'f', LFS_NAME_MAX);
+    f_name[LFS_NAME_MAX] = '\0';
+    char g_name[512];
+    memset(g_name, 'g', LFS_NAME_MAX);
+    g_name[LFS_NAME_MAX] = '\0';
+    char h_name[512];
+    memset(h_name, 'h', LFS_NAME_MAX);
+    h_name[LFS_NAME_MAX] = '\0';
+    char i_name[512];
+    memset(i_name, 'i', LFS_NAME_MAX);
+    i_name[LFS_NAME_MAX] = '\0';
+    char j_name[512];
+    memset(j_name, 'j', LFS_NAME_MAX);
+    j_name[LFS_NAME_MAX] = '\0';
+    char k_name[512];
+    memset(k_name, 'k', LFS_NAME_MAX);
+    k_name[LFS_NAME_MAX] = '\0';
+    char l_name[512];
+    memset(l_name, 'l', LFS_NAME_MAX);
+    l_name[LFS_NAME_MAX] = '\0';
+
+    // create names that aren't too long
+    lfs_mkdir(&lfs, c_name) => 0;
     char path[1024];
-    memset(path, 'w', LFS_NAME_MAX);
-    path[LFS_NAME_MAX] = '\0';
-    lfs_mkdir(&lfs, path) => 0;
+    if (DIR) {
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_mkdir(&lfs, path) => 0;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_mkdir(&lfs, path) => 0;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_mkdir(&lfs, path) => 0;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_mkdir(&lfs, path) => 0;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_mkdir(&lfs, path) => 0;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_mkdir(&lfs, path) => 0;
+    } else {
+        lfs_file_t file;
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    sprintf(path, "%s/%s", c_name, a_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, a_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", c_name, b_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, b_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", c_name, c_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, c_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", c_name, d_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, d_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", c_name, e_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, e_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", c_name, f_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, f_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_dir_open(&lfs, &dir, path) => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_dir_open(&lfs, &dir, path) => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, e_name) => 0;
+    char path_[1024];
+    sprintf(path, "%s/%s", c_name, a_name);
+    sprintf(path_, "%s/%s", e_name, g_name);
+    lfs_rename(&lfs, path, path_) => 0;
+    sprintf(path, "%s/%s", c_name, b_name);
+    sprintf(path_, "%s/%s", e_name, h_name);
+    lfs_rename(&lfs, path, path_) => 0;
+    sprintf(path, "%s/%s", c_name, c_name);
+    sprintf(path_, "%s/%s", e_name, i_name);
+    lfs_rename(&lfs, path, path_) => 0;
+    sprintf(path, "%s/%s", c_name, d_name);
+    sprintf(path_, "%s/%s", e_name, j_name);
+    lfs_rename(&lfs, path, path_) => 0;
+    sprintf(path, "%s/%s", c_name, e_name);
+    sprintf(path_, "%s/%s", e_name, k_name);
+    lfs_rename(&lfs, path, path_) => 0;
+    sprintf(path, "%s/%s", c_name, f_name);
+    sprintf(path_, "%s/%s", e_name, l_name);
+    lfs_rename(&lfs, path, path_) => 0;
+
+    // stat paths
+    sprintf(path, "%s/%s", e_name, g_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, g_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", e_name, h_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, h_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", e_name, i_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, i_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", e_name, j_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, j_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", e_name, k_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, k_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    sprintf(path, "%s/%s", e_name, l_name);
+    lfs_stat(&lfs, path, &info) => 0;
+    assert(strcmp(info.name, l_name) == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    sprintf(path, "%s/%s", c_name, a_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", c_name, b_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", c_name, c_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", c_name, d_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", c_name, e_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", c_name, f_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    sprintf(path, "%s/%s", e_name, g_name);
     lfs_remove(&lfs, path) => 0;
-    lfs_file_t file;
-    lfs_file_open(&lfs, &file, path,
-            LFS_O_WRONLY | LFS_O_CREAT) => 0;
-    lfs_file_close(&lfs, &file) => 0;
+    sprintf(path, "%s/%s", e_name, h_name);
+    lfs_remove(&lfs, path) => 0;
+    sprintf(path, "%s/%s", e_name, i_name);
+    lfs_remove(&lfs, path) => 0;
+    sprintf(path, "%s/%s", e_name, j_name);
+    lfs_remove(&lfs, path) => 0;
+    sprintf(path, "%s/%s", e_name, k_name);
+    lfs_remove(&lfs, path) => 0;
+    sprintf(path, "%s/%s", e_name, l_name);
     lfs_remove(&lfs, path) => 0;
 
-    memcpy(path, "coffee/", strlen("coffee/"));
-    memset(path+strlen("coffee/"), 'w', LFS_NAME_MAX);
-    path[strlen("coffee/")+LFS_NAME_MAX] = '\0';
-    lfs_mkdir(&lfs, path) => 0;
-    lfs_remove(&lfs, path) => 0;
-    lfs_file_open(&lfs, &file, path,
-            LFS_O_WRONLY | LFS_O_CREAT) => 0;
-    lfs_file_close(&lfs, &file) => 0;
-    lfs_remove(&lfs, path) => 0;
+    // stat paths
+    sprintf(path, "%s/%s", e_name, g_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", e_name, h_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", e_name, i_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", e_name, j_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", e_name, k_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+    sprintf(path, "%s/%s", e_name, l_name);
+    lfs_stat(&lfs, path, &info) => LFS_ERR_NOENT;
+
     lfs_unmount(&lfs) => 0;
 '''
 
+# a quick utf8 test, though utf8 is easy to support
+[cases.test_paths_utf8]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/dripcoffee") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/türkkahvesi") => 0;
+        lfs_mkdir(&lfs, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀") => 0;
+        lfs_mkdir(&lfs, "coffee/càphêđá") => 0;
+        lfs_mkdir(&lfs, "coffee/โอเลี้ยง") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "coffee/dripcoffee", &info) => 0;
+    assert(strcmp(info.name, "dripcoffee") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/türkkahvesi", &info) => 0;
+    assert(strcmp(info.name, "türkkahvesi") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀", &info) => 0;
+    assert(strcmp(info.name, "ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/càphêđá", &info) => 0;
+    assert(strcmp(info.name, "càphêđá") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/โอเลี้ยง", &info) => 0;
+    assert(strcmp(info.name, "โอเลี้ยง") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/dripcoffee") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/türkkahvesi") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/càphêđá") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/โอเลี้ยง") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/dripcoffee") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/türkkahvesi") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/càphêđá") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/โอเลี้ยง") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "caffè") => 0;
+    lfs_rename(&lfs,
+            "coffee/dripcoffee",
+            "caffè/espresso") => 0;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "caffè/americano") => 0;
+    lfs_rename(&lfs,
+            "coffee/türkkahvesi",
+            "caffè/macchiato") => 0;
+    lfs_rename(&lfs,
+            "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+            "caffè/latte") => 0;
+    lfs_rename(&lfs,
+            "coffee/càphêđá",
+            "caffè/cappuccino") => 0;
+    lfs_rename(&lfs,
+            "coffee/โอเลี้ยง",
+            "caffè/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "caffè/espresso", &info) => 0;
+    assert(strcmp(info.name, "espresso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "caffè/americano", &info) => 0;
+    assert(strcmp(info.name, "americano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "caffè/macchiato", &info) => 0;
+    assert(strcmp(info.name, "macchiato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "caffè/latte", &info) => 0;
+    assert(strcmp(info.name, "latte") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "caffè/cappuccino", &info) => 0;
+    assert(strcmp(info.name, "cappuccino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "caffè/mocha", &info) => 0;
+    assert(strcmp(info.name, "mocha") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "coffee/dripcoffee", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/türkkahvesi", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/càphêđá", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/โอเลี้ยง", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "caffè/espresso") => 0;
+    lfs_remove(&lfs, "caffè/americano") => 0;
+    lfs_remove(&lfs, "caffè/macchiato") => 0;
+    lfs_remove(&lfs, "caffè/latte") => 0;
+    lfs_remove(&lfs, "caffè/cappuccino") => 0;
+    lfs_remove(&lfs, "caffè/mocha") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "caffè/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "caffè/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "caffè/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "caffè/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "caffè/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "caffè/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# more utf8 tests
+[cases.test_paths_utf8_ipa]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "ˈkɔ.fi") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "ˈkɔ.fi/dɹɪpˈkɔ.fi") => 0;
+        lfs_mkdir(&lfs, "ˈkɔ.fi/koʊldbɹuː") => 0;
+        lfs_mkdir(&lfs, "ˈkɔ.fi/tyɾckɑhvɛˈsi") => 0;
+        lfs_mkdir(&lfs, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚") => 0;
+        lfs_mkdir(&lfs, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥") => 0;
+        lfs_mkdir(&lfs, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "ˈkɔ.fi/dɹɪpˈkɔ.fi", &info) => 0;
+    assert(strcmp(info.name, "dɹɪpˈkɔ.fi") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "ˈkɔ.fi/koʊldbɹuː", &info) => 0;
+    assert(strcmp(info.name, "koʊldbɹuː") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "ˈkɔ.fi/tyɾckɑhvɛˈsi", &info) => 0;
+    assert(strcmp(info.name, "tyɾckɑhvɛˈsi") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚", &info) => 0;
+    assert(strcmp(info.name, "ˈko.piˈt̪up̚.rʊk̚") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥", &info) => 0;
+    assert(strcmp(info.name, "kaː˨˩fe˧˧ɗaː˧˥") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥", &info) => 0;
+    assert(strcmp(info.name, "ʔoː˧.lia̯ŋ˦˥") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/dɹɪpˈkɔ.fi") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/koʊldbɹuː") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/tyɾckɑhvɛˈsi") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/dɹɪpˈkɔ.fi") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/koʊldbɹuː") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/tyɾckɑhvɛˈsi") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "kafˈfɛ") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+            "kafˈfɛ/eˈsprɛsso") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/koʊldbɹuː",
+            "kafˈfɛ/ameriˈkano") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+            "kafˈfɛ/makˈkjato") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+            "kafˈfɛ/ˈlat.te") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+            "kafˈfɛ/kapputˈt͡ʃino") => 0;
+    lfs_rename(&lfs,
+            "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+            "kafˈfɛ/ˈmoʊkə") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "kafˈfɛ/eˈsprɛsso", &info) => 0;
+    assert(strcmp(info.name, "eˈsprɛsso") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "kafˈfɛ/ameriˈkano", &info) => 0;
+    assert(strcmp(info.name, "ameriˈkano") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "kafˈfɛ/makˈkjato", &info) => 0;
+    assert(strcmp(info.name, "makˈkjato") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "kafˈfɛ/ˈlat.te", &info) => 0;
+    assert(strcmp(info.name, "ˈlat.te") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "kafˈfɛ/kapputˈt͡ʃino", &info) => 0;
+    assert(strcmp(info.name, "kapputˈt͡ʃino") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "kafˈfɛ/ˈmoʊkə", &info) => 0;
+    assert(strcmp(info.name, "ˈmoʊkə") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "ˈkɔ.fi/dɹɪpˈkɔ.fi", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "ˈkɔ.fi/koʊldbɹuː", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "ˈkɔ.fi/tyɾckɑhvɛˈsi", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "kafˈfɛ/eˈsprɛsso") => 0;
+    lfs_remove(&lfs, "kafˈfɛ/ameriˈkano") => 0;
+    lfs_remove(&lfs, "kafˈfɛ/makˈkjato") => 0;
+    lfs_remove(&lfs, "kafˈfɛ/ˈlat.te") => 0;
+    lfs_remove(&lfs, "kafˈfɛ/kapputˈt͡ʃino") => 0;
+    lfs_remove(&lfs, "kafˈfɛ/ˈmoʊkə") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "kafˈfɛ/eˈsprɛsso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "kafˈfɛ/ameriˈkano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "kafˈfɛ/makˈkjato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "kafˈfɛ/ˈlat.te", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "kafˈfɛ/kapputˈt͡ʃino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "kafˈfɛ/ˈmoʊkə", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test spaces have no problems
+[cases.test_paths_spaces]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "c o f f e e") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "c o f f e e/d r i p") => 0;
+        lfs_mkdir(&lfs, "c o f f e e/c o l d b r e w") => 0;
+        lfs_mkdir(&lfs, "c o f f e e/t u r k i s h") => 0;
+        lfs_mkdir(&lfs, "c o f f e e/t u b r u k") => 0;
+        lfs_mkdir(&lfs, "c o f f e e/v i e t n a m e s e") => 0;
+        lfs_mkdir(&lfs, "c o f f e e/t h a i") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "c o f f e e/d r i p", &info) => 0;
+    assert(strcmp(info.name, "d r i p") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "c o f f e e/c o l d b r e w", &info) => 0;
+    assert(strcmp(info.name, "c o l d b r e w") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "c o f f e e/t u r k i s h", &info) => 0;
+    assert(strcmp(info.name, "t u r k i s h") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "c o f f e e/t u b r u k", &info) => 0;
+    assert(strcmp(info.name, "t u b r u k") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "c o f f e e/v i e t n a m e s e", &info) => 0;
+    assert(strcmp(info.name, "v i e t n a m e s e") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "c o f f e e/t h a i", &info) => 0;
+    assert(strcmp(info.name, "t h a i") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/d r i p") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/c o l d b r e w") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t u r k i s h") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t u b r u k") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/v i e t n a m e s e") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t h a i") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/d r i p") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/c o l d b r e w") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t u r k i s h") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t u b r u k") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/v i e t n a m e s e") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "c o f f e e/t h a i") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "e s p r e s s o") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/d r i p",
+            "e s p r e s s o/e s p r e s s o") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/c o l d b r e w",
+            "e s p r e s s o/a m e r i c a n o") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/t u r k i s h",
+            "e s p r e s s o/m a c c h i a t o") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/t u b r u k",
+            "e s p r e s s o/l a t t e") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/v i e t n a m e s e",
+            "e s p r e s s o/c a p p u c c i n o") => 0;
+    lfs_rename(&lfs,
+            "c o f f e e/t h a i",
+            "e s p r e s s o/m o c h a") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "e s p r e s s o/e s p r e s s o", &info) => 0;
+    assert(strcmp(info.name, "e s p r e s s o") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "e s p r e s s o/a m e r i c a n o", &info) => 0;
+    assert(strcmp(info.name, "a m e r i c a n o") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "e s p r e s s o/m a c c h i a t o", &info) => 0;
+    assert(strcmp(info.name, "m a c c h i a t o") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "e s p r e s s o/l a t t e", &info) => 0;
+    assert(strcmp(info.name, "l a t t e") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "e s p r e s s o/c a p p u c c i n o", &info) => 0;
+    assert(strcmp(info.name, "c a p p u c c i n o") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "e s p r e s s o/m o c h a", &info) => 0;
+    assert(strcmp(info.name, "m o c h a") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "c o f f e e/d r i p", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c o f f e e/c o l d b r e w", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c o f f e e/t u r k i s h", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c o f f e e/t u b r u k", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c o f f e e/v i e t n a m e s e", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "c o f f e e/t h a i", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "e s p r e s s o/e s p r e s s o") => 0;
+    lfs_remove(&lfs, "e s p r e s s o/a m e r i c a n o") => 0;
+    lfs_remove(&lfs, "e s p r e s s o/m a c c h i a t o") => 0;
+    lfs_remove(&lfs, "e s p r e s s o/l a t t e") => 0;
+    lfs_remove(&lfs, "e s p r e s s o/c a p p u c c i n o") => 0;
+    lfs_remove(&lfs, "e s p r e s s o/m o c h a") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "e s p r e s s o/e s p r e s s o", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "e s p r e s s o/a m e r i c a n o", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "e s p r e s s o/m a c c h i a t o", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "e s p r e s s o/l a t t e", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "e s p r e s s o/c a p p u c c i n o", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "e s p r e s s o/m o c h a", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test with only spaces
+#
+# please don't do this
+[cases.test_paths_oopsallspaces]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, " ") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, " / ") => 0;
+        lfs_mkdir(&lfs, " /  ") => 0;
+        lfs_mkdir(&lfs, " /   ") => 0;
+        lfs_mkdir(&lfs, " /    ") => 0;
+        lfs_mkdir(&lfs, " /     ") => 0;
+        lfs_mkdir(&lfs, " /      ") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, " / ", &info) => 0;
+    assert(strcmp(info.name, " ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, " /  ", &info) => 0;
+    assert(strcmp(info.name, "  ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, " /   ", &info) => 0;
+    assert(strcmp(info.name, "   ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, " /    ", &info) => 0;
+    assert(strcmp(info.name, "    ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, " /     ", &info) => 0;
+    assert(strcmp(info.name, "     ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, " /      ", &info) => 0;
+    assert(strcmp(info.name, "      ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, " / ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, " /  ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, " /   ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, " /    ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, " /     ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, " /      ") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, " / ") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, " /  ") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, " /   ") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, " /    ") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, " /     ") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, " /      ") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "  ") => 0;
+    lfs_rename(&lfs,
+            " / ",
+            "  /      ") => 0;
+    lfs_rename(&lfs,
+            " /  ",
+            "  /       ") => 0;
+    lfs_rename(&lfs,
+            " /   ",
+            "  /        ") => 0;
+    lfs_rename(&lfs,
+            " /    ",
+            "  /         ") => 0;
+    lfs_rename(&lfs,
+            " /     ",
+            "  /          ") => 0;
+    lfs_rename(&lfs,
+            " /      ",
+            "  /           ") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "  /      ", &info) => 0;
+    assert(strcmp(info.name, "      ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "  /       ", &info) => 0;
+    assert(strcmp(info.name, "       ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "  /        ", &info) => 0;
+    assert(strcmp(info.name, "        ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "  /         ", &info) => 0;
+    assert(strcmp(info.name, "         ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "  /          ", &info) => 0;
+    assert(strcmp(info.name, "          ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "  /           ", &info) => 0;
+    assert(strcmp(info.name, "           ") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, " / ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, " /  ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, " /   ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, " /    ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, " /     ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, " /      ", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "  /      ") => 0;
+    lfs_remove(&lfs, "  /       ") => 0;
+    lfs_remove(&lfs, "  /        ") => 0;
+    lfs_remove(&lfs, "  /         ") => 0;
+    lfs_remove(&lfs, "  /          ") => 0;
+    lfs_remove(&lfs, "  /           ") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "  /      ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "  /       ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "  /        ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "  /         ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "  /          ", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "  /           ", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test with only ascii control characters
+#
+# littlefs only cares about "./" and NULL
+[cases.test_paths_nonprintable]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "\x0c") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "\x0c/\x01") => 0;
+        lfs_mkdir(&lfs, "\x0c/\x02") => 0;
+        lfs_mkdir(&lfs, "\x0c/\x03") => 0;
+        lfs_mkdir(&lfs, "\x0c/\x04") => 0;
+        lfs_mkdir(&lfs, "\x0c/\x05") => 0;
+        lfs_mkdir(&lfs, "\x0c/\x06") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "\x0c/\x01", &info) => 0;
+    assert(strcmp(info.name, "\x01") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0c/\x02", &info) => 0;
+    assert(strcmp(info.name, "\x02") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0c/\x03", &info) => 0;
+    assert(strcmp(info.name, "\x03") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0c/\x04", &info) => 0;
+    assert(strcmp(info.name, "\x04") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0c/\x05", &info) => 0;
+    assert(strcmp(info.name, "\x05") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0c/\x06", &info) => 0;
+    assert(strcmp(info.name, "\x06") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x01") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x02") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x03") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x04") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x05") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x06") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x01") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x02") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x03") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x04") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x05") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x0c/\x06") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "\x0e") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x01",
+            "\x0e/\x1a") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x02",
+            "\x0e/\x1b") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x03",
+            "\x0e/\x1c") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x04",
+            "\x0e/\x1d") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x05",
+            "\x0e/\x1e") => 0;
+    lfs_rename(&lfs,
+            "\x0c/\x06",
+            "\x0e/\x1f") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\x0e/\x1a", &info) => 0;
+    assert(strcmp(info.name, "\x1a") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0e/\x1b", &info) => 0;
+    assert(strcmp(info.name, "\x1b") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0e/\x1c", &info) => 0;
+    assert(strcmp(info.name, "\x1c") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0e/\x1d", &info) => 0;
+    assert(strcmp(info.name, "\x1d") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0e/\x1e", &info) => 0;
+    assert(strcmp(info.name, "\x1e") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x0e/\x1f", &info) => 0;
+    assert(strcmp(info.name, "\x1f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "\x0c/\x01", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0c/\x02", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0c/\x03", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0c/\x04", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0c/\x05", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0c/\x06", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "\x0e/\x1a") => 0;
+    lfs_remove(&lfs, "\x0e/\x1b") => 0;
+    lfs_remove(&lfs, "\x0e/\x1c") => 0;
+    lfs_remove(&lfs, "\x0e/\x1d") => 0;
+    lfs_remove(&lfs, "\x0e/\x1e") => 0;
+    lfs_remove(&lfs, "\x0e/\x1f") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\x0e/\x1a", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0e/\x1b", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0e/\x1c", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0e/\x1d", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0e/\x1e", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x0e/\x1f", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test with only ascii DELs
+#
+# I don't know why you'd do this
+[cases.test_paths_oopsalldels]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "\x7f") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "\x7f/\x7f") => 0;
+        lfs_mkdir(&lfs, "\x7f/\x7f\x7f") => 0;
+        lfs_mkdir(&lfs, "\x7f/\x7f\x7f\x7f") => 0;
+        lfs_mkdir(&lfs, "\x7f/\x7f\x7f\x7f\x7f") => 0;
+        lfs_mkdir(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f") => 0;
+        lfs_mkdir(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "\x7f/\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f/\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f\x7f") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f\x7f\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f\x7f\x7f\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f\x7f\x7f\x7f\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_rename(&lfs,
+            "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+            "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => 0;
+    assert(strcmp(info.name, "\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "\x7f/\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f/\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+    lfs_remove(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\x7f\x7f/\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f\x7f", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test with invalid utf8 sequences
+#
+# Don't do this! These filenames are not utf8 and will probably break
+# external tools.
+#
+[cases.test_paths_nonutf8]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "\xc0") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "\xc0/\xa0") => 0;
+        lfs_mkdir(&lfs, "\xc0/\xb0") => 0;
+        lfs_mkdir(&lfs, "\xc0/\xc0") => 0;
+        lfs_mkdir(&lfs, "\xc0/\xd0") => 0;
+        lfs_mkdir(&lfs, "\xc0/\xe0") => 0;
+        lfs_mkdir(&lfs, "\xc0/\xf0") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "\xc0/\xa0", &info) => 0;
+    assert(strcmp(info.name, "\xa0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xc0/\xb0", &info) => 0;
+    assert(strcmp(info.name, "\xb0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xc0/\xc0", &info) => 0;
+    assert(strcmp(info.name, "\xc0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xc0/\xd0", &info) => 0;
+    assert(strcmp(info.name, "\xd0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xc0/\xe0", &info) => 0;
+    assert(strcmp(info.name, "\xe0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xc0/\xf0", &info) => 0;
+    assert(strcmp(info.name, "\xf0") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xa0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xb0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xc0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xd0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xe0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xf0") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xa0") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xb0") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xc0") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xd0") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xe0") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xc0/\xf0") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "\xe0") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xa0",
+            "\xe0/\xaf") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xb0",
+            "\xe0/\xbf") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xc0",
+            "\xe0/\xcf") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xd0",
+            "\xe0/\xdf") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xe0",
+            "\xe0/\xef") => 0;
+    lfs_rename(&lfs,
+            "\xc0/\xf0",
+            "\xe0/\xff") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\xe0/\xaf", &info) => 0;
+    assert(strcmp(info.name, "\xaf") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xe0/\xbf", &info) => 0;
+    assert(strcmp(info.name, "\xbf") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xe0/\xcf", &info) => 0;
+    assert(strcmp(info.name, "\xcf") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xe0/\xdf", &info) => 0;
+    assert(strcmp(info.name, "\xdf") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xe0/\xef", &info) => 0;
+    assert(strcmp(info.name, "\xef") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xe0/\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "\xc0/\xa0", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xc0/\xb0", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xc0/\xc0", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xc0/\xd0", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xc0/\xe0", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xc0/\xf0", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "\xe0/\xaf") => 0;
+    lfs_remove(&lfs, "\xe0/\xbf") => 0;
+    lfs_remove(&lfs, "\xe0/\xcf") => 0;
+    lfs_remove(&lfs, "\xe0/\xdf") => 0;
+    lfs_remove(&lfs, "\xe0/\xef") => 0;
+    lfs_remove(&lfs, "\xe0/\xff") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\xe0/\xaf", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xe0/\xbf", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xe0/\xcf", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xe0/\xdf", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xe0/\xef", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xe0/\xff", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# test with only "\xff" characters
+#
+# Don't do this! These filenames are not utf8 and will probably break
+# external tools.
+#
+[cases.test_paths_oopsallffs]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "\xff") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "\xff/\xff") => 0;
+        lfs_mkdir(&lfs, "\xff/\xff\xff") => 0;
+        lfs_mkdir(&lfs, "\xff/\xff\xff\xff") => 0;
+        lfs_mkdir(&lfs, "\xff/\xff\xff\xff\xff") => 0;
+        lfs_mkdir(&lfs, "\xff/\xff\xff\xff\xff\xff") => 0;
+        lfs_mkdir(&lfs, "\xff/\xff\xff\xff\xff\xff\xff") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "\xff/\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff/\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff/\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_RDONLY) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff\xff\xff") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff\xff") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "\xff/\xff\xff\xff\xff\xff\xff") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff\xff\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff\xff\xff\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff\xff\xff\xff\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_rename(&lfs,
+            "\xff/\xff\xff\xff\xff\xff\xff",
+            "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => 0;
+    assert(strcmp(info.name, "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_stat(&lfs, "\xff/\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff/\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff/\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff/\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+    lfs_remove(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff") => 0;
+
+    // stat paths
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "\xff\xff/\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", &info) => LFS_ERR_NOENT;
+
+    lfs_unmount(&lfs) => 0;
+'''

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -3216,6 +3216,58 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
+# test an empty path, this should error
+[cases.test_paths_empty]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    struct lfs_info info;
+
+    // create empty, this should error
+    if (DIR) {
+        lfs_mkdir(&lfs, "") => LFS_ERR_INVAL;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    }
+
+    // stat empty
+    lfs_stat(&lfs, "", &info) => LFS_ERR_INVAL;
+
+    // file open empty, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+
+    // dir open empty, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "") => LFS_ERR_INVAL;
+    lfs_dir_close(&lfs, &dir) => 0;
+
+    // rename empty, this should error
+    lfs_rename(&lfs, "", "coffee") => LFS_ERR_INVAL;
+
+    lfs_mkdir(&lfs, "coffee") => 0;
+    lfs_rename(&lfs, "coffee", "") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee") => 0;
+
+    lfs_rename(&lfs, "", "") => LFS_ERR_INVAL;
+
+    // stat empty
+    lfs_stat(&lfs, "", &info) => LFS_ERR_INVAL;
+
+    // remove empty, this should error
+    lfs_remove(&lfs, "") => LFS_ERR_INVAL;
+
+    // stat empty
+    lfs_stat(&lfs, "", &info) => LFS_ERR_INVAL;
+
+    lfs_unmount(&lfs) => 0;
+'''
+
 # root operations
 #
 # POSIX deviations:
@@ -3294,7 +3346,6 @@ code = '''
     // create root, this should error
     if (DIR) {
         lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, ".") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "./") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "/.") => LFS_ERR_EXIST;
@@ -3302,8 +3353,6 @@ code = '''
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/",
-                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "",
                 LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, ".",
                 LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
@@ -3317,9 +3366,6 @@ code = '''
 
     // stat root
     lfs_stat(&lfs, "/", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, ".", &info) => 0;
@@ -3339,8 +3385,6 @@ code = '''
     lfs_file_t file;
     lfs_file_open(&lfs, &file, "/",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
-    lfs_file_open(&lfs, &file, "",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, ".",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, "./",
@@ -3354,8 +3398,6 @@ code = '''
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "/") => 0;
     lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, ".") => 0;
     lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, "./") => 0;
@@ -3367,7 +3409,6 @@ code = '''
 
     // rename root, this should error
     lfs_rename(&lfs, "/", "coffee") => LFS_ERR_INVAL;
-    lfs_rename(&lfs, "", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, ".", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "./", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "/.", "coffee") => LFS_ERR_INVAL;
@@ -3375,7 +3416,6 @@ code = '''
 
     lfs_mkdir(&lfs, "coffee") => 0;
     lfs_rename(&lfs, "coffee", "/") => LFS_ERR_INVAL;
-    lfs_rename(&lfs, "coffee", "") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", ".") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "./") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "/.") => LFS_ERR_INVAL;
@@ -3383,7 +3423,6 @@ code = '''
     lfs_remove(&lfs, "coffee") => 0;
 
     lfs_rename(&lfs, "/", "/") => LFS_ERR_INVAL;
-    lfs_rename(&lfs, "", "") => LFS_ERR_INVAL;
     lfs_rename(&lfs, ".", ".") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "..", "..") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "./", "./") => LFS_ERR_INVAL;
@@ -3392,9 +3431,6 @@ code = '''
 
     // stat root
     lfs_stat(&lfs, "/", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, ".", &info) => 0;
@@ -3412,7 +3448,6 @@ code = '''
 
     // remove root, this should error
     lfs_remove(&lfs, "/") => LFS_ERR_INVAL;
-    lfs_remove(&lfs, "") => LFS_ERR_INVAL;
     lfs_remove(&lfs, ".") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "./") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "/.") => LFS_ERR_INVAL;
@@ -3420,9 +3455,6 @@ code = '''
 
     // stat root
     lfs_stat(&lfs, "/", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, ".", &info) => 0;

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -74,6 +74,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "coffee/thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/drip",
@@ -94,6 +120,38 @@ code = '''
         lfs_file_open(&lfs, &file, "coffee/thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -265,6 +323,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/coffee/thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/drip",
@@ -285,6 +369,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/coffee/thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -454,6 +570,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "//////coffee//////thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/drip",
@@ -474,6 +616,38 @@ code = '''
         lfs_file_open(&lfs, &file, "//////coffee//////thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "//coffee//coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "///coffee///turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "////coffee////tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/////coffee/////vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "//////coffee//////thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -668,6 +842,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "coffee/thai//////",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/drip/",
@@ -682,6 +882,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/thai//////",
                 LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     }
 
     // dir open paths, only works on dirs!
@@ -949,6 +1175,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/drip",
@@ -969,6 +1221,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./coffee/./coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/././coffee/././turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./././coffee/./././tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/././././coffee/././././vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/./././././coffee/./././././thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -1178,6 +1462,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/drip/.",
@@ -1192,6 +1502,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_NOTDIR;
         lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
                 LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
     }
 
     // dir open paths, only works on dirs!
@@ -1503,6 +1839,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/drip",
@@ -1523,6 +1885,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/no/../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../coffee/no/../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/../../no/no/../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -1719,6 +2113,32 @@ code = '''
             LFS_O_RDONLY) => LFS_ERR_INVAL;
     lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
             LFS_O_RDONLY) => LFS_ERR_INVAL;
+
+    lfs_file_open(&lfs, &file, "coffee/drip/..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+
+    lfs_file_open(&lfs, &file, "coffee/drip/..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
 
     // dir open paths, only works on dirs!
     lfs_dir_t dir;
@@ -1923,6 +2343,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/drip",
@@ -1943,6 +2389,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/./../coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/no/./../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../coffee/no/./../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/no/no/./.././../no/no/./.././../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -2113,6 +2591,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/coffee/.../thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/.../drip",
@@ -2133,6 +2637,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/coffee/.../thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/.../drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.../thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -2303,6 +2839,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "/coffee/......thai",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/coffee/.drip",
@@ -2323,6 +2885,38 @@ code = '''
         lfs_file_open(&lfs, &file, "/coffee/......thai",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "/coffee/.drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/..coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/...turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/....tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/.....vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "/coffee/......thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -2504,6 +3098,32 @@ code = '''
             LFS_O_RDONLY) => LFS_ERR_INVAL;
     lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
             LFS_O_RDONLY) => LFS_ERR_INVAL;
+
+    lfs_file_open(&lfs, &file, "/../coffee/drip",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+
+    lfs_file_open(&lfs, &file, "/../coffee/drip",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
 
     // dir open paths, only works on dirs!
     lfs_dir_t dir;
@@ -2852,6 +3472,32 @@ code = '''
     lfs_file_open(&lfs, &file, "coffee_/thai",
             LFS_O_RDONLY) => LFS_ERR_NOENT;
 
+    lfs_file_open(&lfs, &file, "_offee/drip",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "c_ffee/coldbrew",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "co_fee/turkish",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "cof_ee/tubruk",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "_coffee/vietnamese",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee_/thai",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+
+    lfs_file_open(&lfs, &file, "_offee/drip",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "c_ffee/coldbrew",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "co_fee/turkish",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "cof_ee/tubruk",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "_coffee/vietnamese",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee_/thai",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+
     // dir open paths, only works on dirs!
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "_offee/drip") => LFS_ERR_NOENT;
@@ -3056,6 +3702,32 @@ code = '''
     lfs_file_open(&lfs, &file, "thai/coffee",
             LFS_O_RDONLY) => LFS_ERR_NOTDIR;
 
+    lfs_file_open(&lfs, &file, "drip/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "coldbrew/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "turkish/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "tubruk/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "vietnamese/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "thai/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOTDIR;
+
+    lfs_file_open(&lfs, &file, "drip/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "coldbrew/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "turkish/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "tubruk/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "vietnamese/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+    lfs_file_open(&lfs, &file, "thai/coffee",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOTDIR;
+
     // dir open paths, only works on dirs!
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "drip/coffee") => LFS_ERR_NOTDIR;
@@ -3242,6 +3914,12 @@ code = '''
     lfs_file_open(&lfs, &file, "",
             LFS_O_RDONLY) => LFS_ERR_INVAL;
 
+    lfs_file_open(&lfs, &file, "",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_INVAL;
+
+    lfs_file_open(&lfs, &file, "",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+
     // dir open empty, only works on dirs!
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "") => LFS_ERR_INVAL;
@@ -3303,6 +3981,12 @@ code = '''
     lfs_file_t file;
     lfs_file_open(&lfs, &file, "/",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
 
     // dir open root, only works on dirs!
     lfs_dir_t dir;
@@ -3394,6 +4078,28 @@ code = '''
     lfs_file_open(&lfs, &file, "//",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
 
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, ".",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "./",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "/.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "//",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+    lfs_file_open(&lfs, &file, "/",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, ".",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, "./",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, "/.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+    lfs_file_open(&lfs, &file, "//",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+
     // dir open root, only works on dirs!
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "/") => 0;
@@ -3484,6 +4190,11 @@ code = '''
     struct lfs_info info;
     lfs_stat(&lfs, "littlefs", &info) => LFS_ERR_NOENT;
 
+    // file open littlefs, which shouldn't exist
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "littlefs",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
     // dir open littlefs, which shouldn't exist
     lfs_dir_t dir;
     lfs_dir_open(&lfs, &dir, "littlefs") => LFS_ERR_NOENT;
@@ -3530,11 +4241,24 @@ code = '''
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "littlefs",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "littlefs",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "littlefs",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open littlefs, only works on dirs!
@@ -3786,6 +4510,44 @@ code = '''
         sprintf(path, "%s/%s", c_name, f_name);
         lfs_file_open(&lfs, &file, path,
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         sprintf(path, "%s/%s", c_name, a_name);
@@ -3812,6 +4574,50 @@ code = '''
         lfs_file_open(&lfs, &file, path,
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        sprintf(path, "%s/%s", c_name, a_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, b_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, c_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, d_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, e_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        sprintf(path, "%s/%s", c_name, f_name);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -3943,7 +4749,7 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
-# a quick utf8 test, though utf8 is easy to support
+# a quick utf8 test, utf8 is easy to support
 [cases.test_paths_utf8]
 defines.DIR = [false, true]
 code = '''
@@ -4018,6 +4824,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/dripcoffee",
@@ -4038,6 +4870,38 @@ code = '''
         lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "coffee/dripcoffee",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/türkkahvesi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/ꦏꦺꦴꦥꦶꦠꦸꦧꦿꦸꦏ꧀",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/càphêđá",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "coffee/โอเลี้ยง",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -4207,6 +5071,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
@@ -4227,6 +5117,38 @@ code = '''
         lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/dɹɪpˈkɔ.fi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/koʊldbɹuː",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/tyɾckɑhvɛˈsi",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ˈko.piˈt̪up̚.rʊk̚",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/kaː˨˩fe˧˧ɗaː˧˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "ˈkɔ.fi/ʔoː˧.lia̯ŋ˦˥",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -4396,6 +5318,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
@@ -4416,6 +5364,38 @@ code = '''
         lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "c o f f e e/d r i p",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/c o l d b r e w",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u r k i s h",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t u b r u k",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/v i e t n a m e s e",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "c o f f e e/t h a i",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -4587,6 +5567,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, " /      ",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, " / ",
@@ -4607,6 +5613,38 @@ code = '''
         lfs_file_open(&lfs, &file, " /      ",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, " / ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /  ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /   ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /    ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /     ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, " /      ",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -4778,6 +5816,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "\x0c/\x06",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "\x0c/\x01",
@@ -4798,6 +5862,38 @@ code = '''
         lfs_file_open(&lfs, &file, "\x0c/\x06",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\x0c/\x01",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x02",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x03",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x04",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x05",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x0c/\x06",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -4969,6 +6065,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "\x7f/\x7f",
@@ -4989,6 +6111,38 @@ code = '''
         lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\x7f/\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\x7f/\x7f\x7f\x7f\x7f\x7f\x7f",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -5162,6 +6316,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "\xc0/\xf0",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "\xc0/\xa0",
@@ -5182,6 +6362,38 @@ code = '''
         lfs_file_open(&lfs, &file, "\xc0/\xf0",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\xc0/\xa0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xb0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xc0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xd0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xe0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xc0/\xf0",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!
@@ -5355,6 +6567,32 @@ code = '''
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
                 LFS_O_RDONLY) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "\xff/\xff",
@@ -5375,6 +6613,38 @@ code = '''
         lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
                 LFS_O_RDONLY) => 0;
         lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+
+        lfs_file_open(&lfs, &file, "\xff/\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+        lfs_file_open(&lfs, &file, "\xff/\xff\xff\xff\xff\xff\xff",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
     }
 
     // dir open paths, only works on dirs!

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -1064,6 +1064,14 @@ code = '''
 '''
 
 # test trailing dots, these get a bit weird
+#
+# POSIX deviations:
+#
+# - We accept modifications of directories with trailing dots:
+#   - littlefs: remove("a/.") => 0
+#   - POSIX:    remove("a/.") => EBUSY
+#   Reason: Not worth implementing.
+#
 [cases.test_paths_trailing_dots]
 defines.DIR = [false, true]
 code = '''
@@ -1214,26 +1222,6 @@ code = '''
     // rename paths
     lfs_mkdir(&lfs, "espresso") => 0;
     if (DIR) {
-        // bad source
-        lfs_rename(&lfs,
-                "coffee/drip/./././././.",
-                "espresso/espresso") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/coldbrew/././././.",
-                "espresso/americano") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/turkish/./././.",
-                "espresso/macchiato") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/tubruk/././.",
-                "espresso/latte") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/vietnamese/./.",
-                "espresso/cappuccino") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/thai/.",
-                "espresso/mocha") => LFS_ERR_INVAL;
-
         // bad destination
         lfs_rename(&lfs,
                 "coffee/drip",
@@ -1273,6 +1261,69 @@ code = '''
         lfs_rename(&lfs,
                 "coffee/thai/.",
                 "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+        // this one works
+        lfs_rename(&lfs,
+                "coffee/drip/./././././.",
+                "espresso/espresso") => 0;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/././././.",
+                "espresso/americano") => 0;
+        lfs_rename(&lfs,
+                "coffee/turkish/./././.",
+                "espresso/macchiato") => 0;
+        lfs_rename(&lfs,
+                "coffee/tubruk/././.",
+                "espresso/latte") => 0;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/./.",
+                "espresso/cappuccino") => 0;
+        lfs_rename(&lfs,
+                "coffee/thai/.",
+                "espresso/mocha") => 0;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso/./././././.", &info) => 0;
+        assert(strcmp(info.name, "espresso") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/americano/././././.", &info) => 0;
+        assert(strcmp(info.name, "americano") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/macchiato/./././.", &info) => 0;
+        assert(strcmp(info.name, "macchiato") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/latte/././.", &info) => 0;
+        assert(strcmp(info.name, "latte") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/cappuccino/./.", &info) => 0;
+        assert(strcmp(info.name, "cappuccino") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/mocha/.", &info) => 0;
+        assert(strcmp(info.name, "mocha") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+
+        lfs_stat(&lfs, "coffee/drip/./././././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/coldbrew/././././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/turkish/./././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/tubruk/././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/vietnamese/./.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/thai/.", &info) => LFS_ERR_NOENT;
+
+        // remove paths
+        lfs_remove(&lfs, "espresso/espresso/.") => 0;
+        lfs_remove(&lfs, "espresso/americano/./.") => 0;
+        lfs_remove(&lfs, "espresso/macchiato/././.") => 0;
+        lfs_remove(&lfs, "espresso/latte/./././.") => 0;
+        lfs_remove(&lfs, "espresso/cappuccino/././././.") => 0;
+        lfs_remove(&lfs, "espresso/mocha/./././././.") => 0;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso/./././././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/americano/././././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/macchiato/./././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/latte/././.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/cappuccino/./.", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/mocha/.", &info) => LFS_ERR_NOENT;
 
     } else {
         // bad source
@@ -1334,51 +1385,42 @@ code = '''
         lfs_rename(&lfs,
                 "coffee/thai/.",
                 "espresso/mocha/./././././.") => LFS_ERR_NOTDIR;
-    }
 
-    // remove paths
-    if (DIR) {
-        lfs_remove(&lfs, "coffee/drip/.") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/coldbrew/./.") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/turkish/././.") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/tubruk/./././.") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/vietnamese/././././.") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/thai/./././././.") => LFS_ERR_INVAL;
-    } else {
+        // remove paths
         lfs_remove(&lfs, "coffee/drip/.") => LFS_ERR_NOTDIR;
         lfs_remove(&lfs, "coffee/coldbrew/./.") => LFS_ERR_NOTDIR;
         lfs_remove(&lfs, "coffee/turkish/././.") => LFS_ERR_NOTDIR;
         lfs_remove(&lfs, "coffee/tubruk/./././.") => LFS_ERR_NOTDIR;
         lfs_remove(&lfs, "coffee/vietnamese/././././.") => LFS_ERR_NOTDIR;
         lfs_remove(&lfs, "coffee/thai/./././././.") => LFS_ERR_NOTDIR;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+        lfs_stat(&lfs, "coffee/drip", &info) => 0;
+        assert(strcmp(info.name, "drip") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+        assert(strcmp(info.name, "coldbrew") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+        assert(strcmp(info.name, "turkish") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+        assert(strcmp(info.name, "tubruk") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+        assert(strcmp(info.name, "vietnamese") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/thai", &info) => 0;
+        assert(strcmp(info.name, "thai") == 0);
+        assert(info.type == LFS_TYPE_REG);
     }
-
-    // stat paths
-    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
-
-    lfs_stat(&lfs, "coffee/drip", &info) => 0;
-    assert(strcmp(info.name, "drip") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
-    assert(strcmp(info.name, "coldbrew") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
-    assert(strcmp(info.name, "turkish") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
-    assert(strcmp(info.name, "tubruk") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
-    assert(strcmp(info.name, "vietnamese") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "coffee/thai", &info) => 0;
-    assert(strcmp(info.name, "thai") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
 
     lfs_unmount(&lfs) => 0;
 '''
@@ -1576,6 +1618,19 @@ code = '''
 '''
 
 # test trailing dot dots, these get really weird
+#
+# POSIX deviations:
+#
+# - We do not check for existance of directories followed by dotdots:
+#   - littlefs: stat("a/missing/..") => 0
+#   - POSIX:    stat("a/missing/..") => ENOENT
+#   Reason: Difficult to implement non-recursively.
+#
+# - We accept modifications of directories with trailing dotdots:
+#   - littlefs: rename("a/b/..", "c") => 0
+#   - POSIX:    rename("a/b/..", "c") => EBUSY
+#   Reason: Not worth implementing.
+#
 [cases.test_paths_trailing_dotdots]
 defines.DIR = [false, true]
 code = '''
@@ -1586,12 +1641,12 @@ code = '''
     // create paths
     lfs_mkdir(&lfs, "coffee") => 0;
     if (DIR) {
-        lfs_mkdir(&lfs, "coffee/drip/..") => LFS_ERR_NOENT;
-        lfs_mkdir(&lfs, "coffee/coldbrew/../..") => LFS_ERR_NOENT;
-        lfs_mkdir(&lfs, "coffee/turkish/../../..") => LFS_ERR_NOENT;
-        lfs_mkdir(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_NOENT;
-        lfs_mkdir(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_NOENT;
-        lfs_mkdir(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/drip/..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/coldbrew/../..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/turkish/../../..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_EXIST;
 
         // still create so we have something to test
         lfs_mkdir(&lfs, "coffee/drip") => 0;
@@ -1604,17 +1659,17 @@ code = '''
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "coffee/drip/..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
 
         // still create so we have something to test
         lfs_file_open(&lfs, &file, "coffee/drip",
@@ -1639,231 +1694,138 @@ code = '''
 
     // stat paths
     struct lfs_info info;
-    if (DIR) {
-        lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => 0;
-        assert(strcmp(info.name, "/") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-        lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => 0;
-        assert(strcmp(info.name, "/") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-        lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => 0;
-        assert(strcmp(info.name, "/") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-        lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => 0;
-        assert(strcmp(info.name, "/") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-        lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => 0;
-        assert(strcmp(info.name, "/") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-        lfs_stat(&lfs, "coffee/thai/..", &info) => 0;
-        assert(strcmp(info.name, "coffee") == 0);
-        assert(info.type == LFS_TYPE_DIR);
-    } else {
-        lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => LFS_ERR_NOTDIR;
-        lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => LFS_ERR_NOTDIR;
-        lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => LFS_ERR_NOTDIR;
-        lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => LFS_ERR_NOTDIR;
-        lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => LFS_ERR_NOTDIR;
-        lfs_stat(&lfs, "coffee/thai/..", &info) => LFS_ERR_NOTDIR;
-    }
+    lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/thai/..", &info) => 0;
+    assert(strcmp(info.name, "coffee") == 0);
+    assert(info.type == LFS_TYPE_DIR);
 
     // file open paths, only works on files!
-    if (DIR) {
-        lfs_file_t file;
-        lfs_file_open(&lfs, &file, "coffee/drip/..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-    } else {
-        lfs_file_t file;
-        lfs_file_open(&lfs, &file, "coffee/drip/..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-        lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-        lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-        lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-        lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-        lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
-                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
-    }
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "coffee/drip/..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
 
     // dir open paths, only works on dirs!
-    if (DIR) {
-        lfs_dir_t dir;
-        lfs_dir_open(&lfs, &dir, "coffee/drip/..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-    } else {
-        lfs_dir_t dir;
-        lfs_dir_open(&lfs, &dir, "coffee/drip/..") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => LFS_ERR_NOTDIR;
-    }
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "coffee/drip/..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
 
     // rename paths
     lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "coffee/drip/../../../../../..",
+            "espresso/espresso") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/coldbrew/../../../../..",
+            "espresso/americano") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/turkish/../../../..",
+            "espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tubruk/../../..",
+            "espresso/latte") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/vietnamese/../..",
+            "espresso/cappuccino") => LFS_ERR_INVAL;
+    // this one works
+    lfs_rename(&lfs,
+            "coffee/thai/..",
+            "espresso/mocha") => 0;
+    lfs_rename(&lfs,
+            "espresso/mocha",
+            "coffee") => 0;
+
+    // bad destination
     if (DIR) {
-        // bad source
-        lfs_rename(&lfs,
-                "coffee/drip/../../../../../..",
-                "espresso/espresso") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/coldbrew/../../../../..",
-                "espresso/americano") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/turkish/../../../..",
-                "espresso/macchiato") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/tubruk/../../..",
-                "espresso/latte") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/vietnamese/../..",
-                "espresso/cappuccino") => LFS_ERR_INVAL;
-        lfs_rename(&lfs,
-                "coffee/thai/..",
-                "espresso/mocha") => LFS_ERR_INVAL;
-
-        // bad destination
+        // this one works
         lfs_rename(&lfs,
                 "coffee/drip",
-                "espresso/espresso/..") => LFS_ERR_NOENT;
+                "espresso/espresso/..") => 0;
         lfs_rename(&lfs,
-                "coffee/coldbrew",
-                "espresso/americano/../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/turkish",
-                "espresso/macchiato/../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/tubruk",
-                "espresso/latte/../../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/vietnamese",
-                "espresso/cappuccino/../../../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/thai",
-                "espresso/mocha/../../../../../..") => LFS_ERR_NOENT;
-
-        // bad source and bad destination
-        lfs_rename(&lfs,
-                "coffee/drip/../../../../../..",
-                "espresso/espresso/..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/coldbrew/../../../../..",
-                "espresso/americano/../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/turkish/../../../..",
-                "espresso/macchiato/../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/tubruk/../../..",
-                "espresso/latte/../../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/vietnamese/../..",
-                "espresso/cappuccino/../../../../..") => LFS_ERR_NOENT;
-        lfs_rename(&lfs,
-                "coffee/thai/..",
-                "espresso/mocha/../../../../../..") => LFS_ERR_NOENT;
-
+                "espresso",
+                "coffee/drip") => 0;
     } else {
-        // bad source
-        lfs_rename(&lfs,
-                "coffee/drip/../../../../../..",
-                "espresso/espresso") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/coldbrew/../../../../..",
-                "espresso/americano") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/turkish/../../../..",
-                "espresso/macchiato") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/tubruk/../../..",
-                "espresso/latte") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/vietnamese/../..",
-                "espresso/cappuccino") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/thai/..",
-                "espresso/mocha") => LFS_ERR_NOTDIR;
-
-        // bad destination
         lfs_rename(&lfs,
                 "coffee/drip",
-                "espresso/espresso/..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/coldbrew",
-                "espresso/americano/../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/turkish",
-                "espresso/macchiato/../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/tubruk",
-                "espresso/latte/../../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/vietnamese",
-                "espresso/cappuccino/../../../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/thai",
-                "espresso/mocha/../../../../../..") => LFS_ERR_NOTDIR;
-
-        // bad source and bad destination
-        lfs_rename(&lfs,
-                "coffee/drip/../../../../../..",
-                "espresso/espresso/..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/coldbrew/../../../../..",
-                "espresso/americano/../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/turkish/../../../..",
-                "espresso/macchiato/../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/tubruk/../../..",
-                "espresso/latte/../../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/vietnamese/../..",
-                "espresso/cappuccino/../../../../..") => LFS_ERR_NOTDIR;
-        lfs_rename(&lfs,
-                "coffee/thai/..",
-                "espresso/mocha/../../../../../..") => LFS_ERR_NOTDIR;
+                "espresso/espresso/..") => LFS_ERR_ISDIR;
     }
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "espresso/americano/../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/turkish",
+            "espresso/macchiato/../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tubruk",
+            "espresso/latte/../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/vietnamese",
+            "espresso/cappuccino/../../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/thai",
+            "espresso/mocha/../../../../../..") => LFS_ERR_INVAL;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "coffee/drip/../../../../../..",
+            "espresso/espresso/..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/coldbrew/../../../../..",
+            "espresso/americano/../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/turkish/../../../..",
+            "espresso/macchiato/../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tubruk/../../..",
+            "espresso/latte/../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/vietnamese/../..",
+            "espresso/cappuccino/../../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/thai/..",
+            "espresso/mocha/../../../../../..") => LFS_ERR_INVAL;
 
     // remove paths
-    if (DIR) {
-        lfs_remove(&lfs, "coffee/drip/..") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/coldbrew/../..") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/turkish/../../..") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_INVAL;
-        lfs_remove(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_INVAL;
-    } else {
-        lfs_remove(&lfs, "coffee/drip/..") => LFS_ERR_NOTDIR;
-        lfs_remove(&lfs, "coffee/coldbrew/../..") => LFS_ERR_NOTDIR;
-        lfs_remove(&lfs, "coffee/turkish/../../..") => LFS_ERR_NOTDIR;
-        lfs_remove(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_NOTDIR;
-        lfs_remove(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_NOTDIR;
-        lfs_remove(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_NOTDIR;
-    }
+    lfs_remove(&lfs, "coffee/drip/..") => LFS_ERR_NOTEMPTY;
+    lfs_remove(&lfs, "coffee/coldbrew/../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/turkish/../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_INVAL;
 
     // stat paths
     lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
@@ -3048,6 +3010,14 @@ code = '''
 '''
 
 # root operations
+#
+# POSIX deviations:
+#
+# - Root modifications return EINVAL instead of EBUSY:
+#   - littlefs: remove("/") => EINVAL
+#   - POSIX:    remove("/") => EBUSY
+#   Reason: This would be the only use of EBUSY in the system.
+#
 [cases.test_paths_root]
 defines.DIR = [false, true]
 code = '''

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -3198,23 +3198,23 @@ code = '''
 
     // here's a weird one, what happens if our rename is also a noop?
     lfs_rename(&lfs,
-            "/../coffee/drip",
-            "/../espresso/espresso") => LFS_ERR_INVAL;
+            "/no/../../../../coffee/drip",
+            "/no/../../../../coffee/drip") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
-            "/../../coffee/coldbrew",
-            "/../../espresso/americano") => LFS_ERR_INVAL;
+            "/no/../../../coffee/coldbrew",
+            "/no/../../../coffee/coldbrew") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
-            "/../../../coffee/turkish",
-            "/../../../espresso/macchiato") => LFS_ERR_INVAL;
+            "/no/../../coffee/turkish",
+            "/no/../../coffee/turkish") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
-            "/no/../../coffee/tubruk",
-            "/no/../../espresso/latte") => LFS_ERR_INVAL;
+            "/../../../coffee/tubruk",
+            "/../../../coffee/tubruk") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
-            "/no/../../../coffee/vietnamese",
-            "/no/../../../espresso/cappuccino") => LFS_ERR_INVAL;
+            "/../../coffee/vietnamese",
+            "/../../coffee/vietnamese") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
-            "/no/../../../../coffee/thai",
-            "/no/../../../../espresso/mocha") => LFS_ERR_INVAL;
+            "/../coffee/thai",
+            "/../coffee/thai") => LFS_ERR_INVAL;
 
     // remove paths
     lfs_remove(&lfs, "/../espresso/espresso") => LFS_ERR_INVAL;
@@ -3346,6 +3346,26 @@ code = '''
     lfs_rename(&lfs,
             "coffee/thai_",
             "espresso/mocha") => LFS_ERR_NOENT;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "coffee/_rip",
+            "coffee/_rip") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew",
+            "coffee/c_ldbrew") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish",
+            "coffee/tu_kish") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk",
+            "coffee/tub_uk") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese",
+            "coffee/_vietnamese") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_",
+            "coffee/thai_") => LFS_ERR_NOENT;
 
     // remove paths
     lfs_remove(&lfs, "coffee/_rip") => LFS_ERR_NOENT;
@@ -3865,6 +3885,644 @@ code = '''
     lfs_stat(&lfs, "tubruk/espresso", &info) => LFS_ERR_NOTDIR;
     lfs_stat(&lfs, "vietnamese/espresso", &info) => LFS_ERR_NOTDIR;
     lfs_stat(&lfs, "thai/espresso", &info) => LFS_ERR_NOTDIR;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# noent tests with trailing slashes
+[cases.test_paths_noent_trailing_slashes]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "coffee/_rip//////", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/c_ldbrew/////", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tu_kish////", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tub_uk///", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/_vietnamese//", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/thai_/", &info) => LFS_ERR_NOENT;
+
+    // file open paths, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "coffee/_rip/",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew//",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish///",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk////",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/////",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/thai_//////",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
+    lfs_file_open(&lfs, &file, "coffee/_rip/",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew//",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish///",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk////",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/////",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/thai_//////",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
+
+    lfs_file_open(&lfs, &file, "coffee/_rip/",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew//",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish///",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk////",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/////",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/thai_//////",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "coffee/_rip/") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/c_ldbrew//") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tu_kish///") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tub_uk////") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/_vietnamese/////") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/thai_//////") => LFS_ERR_NOENT;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "coffee/_rip//////",
+            "espresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/////",
+            "espresso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish////",
+            "espresso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk///",
+            "espresso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese//",
+            "espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/",
+            "espresso/mocha") => LFS_ERR_NOENT;
+
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip",
+            "espresso/espresso/") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew",
+            "espresso/americano//") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish",
+            "espresso/macchiato///") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk",
+            "espresso/latte////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese",
+            "espresso/cappuccino/////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_",
+            "espresso/mocha//////") => LFS_ERR_NOENT;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip//////",
+            "espresso/espresso/") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/////",
+            "espresso/americano//") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish////",
+            "espresso/macchiato///") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk///",
+            "espresso/latte////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese//",
+            "espresso/cappuccino/////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/",
+            "espresso/mocha//////") => LFS_ERR_NOENT;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "coffee/_rip//////",
+            "coffee/_rip//////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/////",
+            "coffee/c_ldbrew/////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish////",
+            "coffee/tu_kish////") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk///",
+            "coffee/tub_uk///") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese//",
+            "coffee/_vietnamese//") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/",
+            "coffee/thai_/") => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "coffee/_rip/") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/c_ldbrew//") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tu_kish///") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tub_uk////") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/_vietnamese/////") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/thai_//////") => LFS_ERR_NOENT;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# noent tests with trailing dots
+[cases.test_paths_noent_trailing_dots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "coffee/_rip/./././././.", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/c_ldbrew/././././.", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tu_kish/./././.", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/tub_uk/././.", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/_vietnamese/./.", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "coffee/thai_/.", &info) => LFS_ERR_NOENT;
+
+    // file open paths, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "coffee/_rip/.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew/./.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish/././.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk/./././.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/././././.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/thai_/./././././.",
+            LFS_O_RDONLY) => LFS_ERR_NOENT;
+
+    lfs_file_open(&lfs, &file, "coffee/_rip/.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew/./.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish/././.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk/./././.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/././././.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/thai_/./././././.",
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NOENT;
+
+    lfs_file_open(&lfs, &file, "coffee/_rip/.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew/./.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish/././.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk/./././.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/././././.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+    lfs_file_open(&lfs, &file, "coffee/thai_/./././././.",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "coffee/_rip/.") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/c_ldbrew/./.") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tu_kish/././.") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/tub_uk/./././.") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/_vietnamese/././././.") => LFS_ERR_NOENT;
+    lfs_dir_open(&lfs, &dir, "coffee/thai_/./././././.") => LFS_ERR_NOENT;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "coffee/_rip/./././././.",
+            "espresso/espresso") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/././././.",
+            "espresso/americano") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/./././.",
+            "espresso/macchiato") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/././.",
+            "espresso/latte") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/./.",
+            "espresso/cappuccino") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/.",
+            "espresso/mocha") => LFS_ERR_NOENT;
+
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip",
+            "espresso/espresso/.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew",
+            "espresso/americano/./.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish",
+            "espresso/macchiato/././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk",
+            "espresso/latte/./././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese",
+            "espresso/cappuccino/././././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_",
+            "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip/./././././.",
+            "espresso/espresso/.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/././././.",
+            "espresso/americano/./.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/./././.",
+            "espresso/macchiato/././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/././.",
+            "espresso/latte/./././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/./.",
+            "espresso/cappuccino/././././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/.",
+            "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "coffee/_rip/./././././.",
+            "coffee/_rip/./././././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/././././.",
+            "coffee/c_ldbrew/././././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/./././.",
+            "coffee/tu_kish/./././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/././.",
+            "coffee/tub_uk/././.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/./.",
+            "coffee/_vietnamese/./.") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_/.",
+            "coffee/thai_/.") => LFS_ERR_NOENT;
+
+    // remove paths
+    lfs_remove(&lfs, "coffee/_rip/.") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/c_ldbrew/./.") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tu_kish/././.") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/tub_uk/./././.") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/_vietnamese/././././.") => LFS_ERR_NOENT;
+    lfs_remove(&lfs, "coffee/thai_/./././././.") => LFS_ERR_NOENT;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
+
+# noent tests with trailing dotdots
+[cases.test_paths_noent_trailing_dotdots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    lfs_stat(&lfs, "coffee/_rip/../../../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/c_ldbrew/../../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/tu_kish/../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/tub_uk/../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/_vietnamese/../..", &info) => 0;
+    assert(strcmp(info.name, "/") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/thai_/..", &info) => 0;
+    assert(strcmp(info.name, "coffee") == 0);
+    assert(info.type == LFS_TYPE_DIR);
+
+    // file open paths, only works on files!
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "coffee/_rip/..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/c_ldbrew/../..",
+            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    lfs_file_open(&lfs, &file, "coffee/tu_kish/../../..",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/tub_uk/../../../..",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/_vietnamese/../../../../..",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "coffee/thai_/../../../../../..",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+
+    // dir open paths, only works on dirs!
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "coffee/_rip/..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/c_ldbrew/../..") => 0;
+    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/tu_kish/../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/tub_uk/../../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/_vietnamese/../../../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/thai_/../../../../../..") => LFS_ERR_INVAL;
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
+    lfs_rename(&lfs,
+            "coffee/_rip/../../../../../..",
+            "espresso/espresso") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/../../../../..",
+            "espresso/americano") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/../../../..",
+            "espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/../../..",
+            "espresso/latte") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/../..",
+            "espresso/cappuccino") => LFS_ERR_INVAL;
+    // this one works
+    lfs_rename(&lfs,
+            "coffee/thai_/..",
+            "espresso/mocha") => 0;
+    lfs_rename(&lfs,
+            "espresso/mocha",
+            "coffee") => 0;
+
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip",
+            "espresso/espresso/..") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew",
+            "espresso/americano/../..") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tu_kish",
+            "espresso/macchiato/../../..") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/tub_uk",
+            "espresso/latte/../../../..") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese",
+            "espresso/cappuccino/../../../../..") => LFS_ERR_NOENT;
+    lfs_rename(&lfs,
+            "coffee/thai_",
+            "espresso/mocha/../../../../../..") => LFS_ERR_NOENT;
+
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "coffee/_rip/../../../../../..",
+            "espresso/espresso/..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/../../../../..",
+            "espresso/americano/../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/../../../..",
+            "espresso/macchiato/../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/../../..",
+            "espresso/latte/../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/../..",
+            "espresso/cappuccino/../../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/thai_/..",
+            "espresso/mocha/../../../../../..") => LFS_ERR_INVAL;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "coffee/_rip/../../../../../..",
+            "coffee/_rip/../../../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/c_ldbrew/../../../../..",
+            "coffee/c_ldbrew/../../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tu_kish/../../../..",
+            "coffee/tu_kish/../../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tub_uk/../../..",
+            "coffee/tub_uk/../../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/_vietnamese/../..",
+            "coffee/_vietnamese/../..") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/thai_/..",
+            "coffee/thai_/..") => 0;
+
+    // remove paths
+    lfs_remove(&lfs, "coffee/_rip/..") => LFS_ERR_NOTEMPTY;
+    lfs_remove(&lfs, "coffee/c_ldbrew/../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/tu_kish/../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/tub_uk/../../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/_vietnamese/../../../../..") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "coffee/thai_/../../../../../..") => LFS_ERR_INVAL;
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
 
     lfs_stat(&lfs, "coffee/drip", &info) => 0;
     assert(strcmp(info.name, "drip") == 0);

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -568,7 +568,311 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
-# TODO test trailing slashes
+# test trailing slashes
+#
+# trailing slashes are only allowed on directories
+[cases.test_paths_trailing_slashes]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip/") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew//") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish///") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk////") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese/////") => 0;
+        lfs_mkdir(&lfs, "coffee/thai//////") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_ISDIR;
+
+        // still create so we have something to test
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    if (DIR) {
+        lfs_stat(&lfs, "coffee/drip//////", &info) => 0;
+        assert(strcmp(info.name, "drip") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/coldbrew/////", &info) => 0;
+        assert(strcmp(info.name, "coldbrew") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/turkish////", &info) => 0;
+        assert(strcmp(info.name, "turkish") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/tubruk///", &info) => 0;
+        assert(strcmp(info.name, "tubruk") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/vietnamese//", &info) => 0;
+        assert(strcmp(info.name, "vietnamese") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/thai/", &info) => 0;
+        assert(strcmp(info.name, "thai") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+    } else {
+        lfs_stat(&lfs, "coffee/drip//////", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/coldbrew/////", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/turkish////", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/tubruk///", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/vietnamese//", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/thai/", &info) => LFS_ERR_NOTDIR;
+    }
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew//",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish///",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk////",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/////",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai//////",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew//") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish///") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk////") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/////") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/thai//////") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew//") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish///") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk////") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/////") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/thai//////") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    if (DIR) {
+        lfs_rename(&lfs,
+                "coffee/drip//////",
+                "espresso/espresso/") => 0;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/////",
+                "espresso/americano//") => 0;
+        lfs_rename(&lfs,
+                "coffee/turkish////",
+                "espresso/macchiato///") => 0;
+        lfs_rename(&lfs,
+                "coffee/tubruk///",
+                "espresso/latte////") => 0;
+        lfs_rename(&lfs,
+                "coffee/vietnamese//",
+                "espresso/cappuccino/////") => 0;
+        lfs_rename(&lfs,
+                "coffee/thai/",
+                "espresso/mocha//////") => 0;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso//////", &info) => 0;
+        assert(strcmp(info.name, "espresso") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/americano/////", &info) => 0;
+        assert(strcmp(info.name, "americano") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/macchiato////", &info) => 0;
+        assert(strcmp(info.name, "macchiato") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/latte///", &info) => 0;
+        assert(strcmp(info.name, "latte") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/cappuccino//", &info) => 0;
+        assert(strcmp(info.name, "cappuccino") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "espresso/mocha/", &info) => 0;
+        assert(strcmp(info.name, "mocha") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+
+        lfs_stat(&lfs, "coffee/drip//////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/coldbrew/////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/turkish////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/tubruk///", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/vietnamese//", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "coffee/thai/", &info) => LFS_ERR_NOENT;
+
+        // remove paths
+        lfs_remove(&lfs, "espresso/espresso/") => 0;
+        lfs_remove(&lfs, "espresso/americano//") => 0;
+        lfs_remove(&lfs, "espresso/macchiato///") => 0;
+        lfs_remove(&lfs, "espresso/latte////") => 0;
+        lfs_remove(&lfs, "espresso/cappuccino/////") => 0;
+        lfs_remove(&lfs, "espresso/mocha//////") => 0;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso//////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/americano/////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/macchiato////", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/latte///", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/cappuccino//", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/mocha/", &info) => LFS_ERR_NOENT;
+
+    } else {
+        // bad source
+        lfs_rename(&lfs,
+                "coffee/drip//////",
+                "espresso/espresso") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/////",
+                "espresso/americano") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish////",
+                "espresso/macchiato") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk///",
+                "espresso/latte") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese//",
+                "espresso/cappuccino") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/",
+                "espresso/mocha") => LFS_ERR_NOTDIR;
+
+        // bad destination
+        lfs_rename(&lfs,
+                "coffee/drip",
+                "espresso/espresso/") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew",
+                "espresso/americano//") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish",
+                "espresso/macchiato///") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk",
+                "espresso/latte////") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese",
+                "espresso/cappuccino/////") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai",
+                "espresso/mocha//////") => LFS_ERR_NOTDIR;
+
+        // bad source and bad destination
+        lfs_rename(&lfs,
+                "coffee/drip//////",
+                "espresso/espresso/") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/////",
+                "espresso/americano//") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish////",
+                "espresso/macchiato///") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk///",
+                "espresso/latte////") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese//",
+                "espresso/cappuccino/////") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/",
+                "espresso/mocha//////") => LFS_ERR_NOTDIR;
+
+        // remove paths
+        lfs_remove(&lfs, "coffee/drip/") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/coldbrew//") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/turkish///") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/tubruk////") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/vietnamese/////") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/thai//////") => LFS_ERR_NOTDIR;
+
+        // stat paths
+        lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+        lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+        lfs_stat(&lfs, "coffee/drip", &info) => 0;
+        assert(strcmp(info.name, "drip") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+        assert(strcmp(info.name, "coldbrew") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+        assert(strcmp(info.name, "turkish") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+        assert(strcmp(info.name, "tubruk") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+        assert(strcmp(info.name, "vietnamese") == 0);
+        assert(info.type == LFS_TYPE_REG);
+        lfs_stat(&lfs, "coffee/thai", &info) => 0;
+        assert(strcmp(info.name, "thai") == 0);
+        assert(info.type == LFS_TYPE_REG);
+    }
+
+    lfs_unmount(&lfs) => 0;
+'''
 
 # dot path tests
 [cases.test_paths_dots]
@@ -759,7 +1063,325 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
-# TODO test trailing dots
+# test trailing dots, these get a bit weird
+[cases.test_paths_trailing_dots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip/.") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/coldbrew/./.") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/turkish/././.") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/tubruk/./././.") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/vietnamese/././././.") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/thai/./././././.") => LFS_ERR_NOENT;
+
+        // still create so we have something to test
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+
+        // still create so we have something to test
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    if (DIR) {
+        lfs_stat(&lfs, "coffee/drip/./././././.", &info) => 0;
+        assert(strcmp(info.name, "drip") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/coldbrew/././././.", &info) => 0;
+        assert(strcmp(info.name, "coldbrew") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/turkish/./././.", &info) => 0;
+        assert(strcmp(info.name, "turkish") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/tubruk/././.", &info) => 0;
+        assert(strcmp(info.name, "tubruk") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/vietnamese/./.", &info) => 0;
+        assert(strcmp(info.name, "vietnamese") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/thai/.", &info) => 0;
+        assert(strcmp(info.name, "thai") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+    } else {
+        lfs_stat(&lfs, "coffee/drip/./././././.", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/coldbrew/././././.", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/turkish/./././.", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/tubruk/././.", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/vietnamese/./.", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/thai/.", &info) => LFS_ERR_NOTDIR;
+    }
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/./.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/././.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/./././.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/././././.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/./././././.",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/./.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish/././.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk/./././.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/././././.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/thai/./././././.") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/.") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/./.") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish/././.") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk/./././.") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/././././.") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/thai/./././././.") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    if (DIR) {
+        // bad source
+        lfs_rename(&lfs,
+                "coffee/drip/./././././.",
+                "espresso/espresso") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/././././.",
+                "espresso/americano") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/turkish/./././.",
+                "espresso/macchiato") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/tubruk/././.",
+                "espresso/latte") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/./.",
+                "espresso/cappuccino") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/thai/.",
+                "espresso/mocha") => LFS_ERR_INVAL;
+
+        // bad destination
+        lfs_rename(&lfs,
+                "coffee/drip",
+                "espresso/espresso/.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/coldbrew",
+                "espresso/americano/./.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/turkish",
+                "espresso/macchiato/././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/tubruk",
+                "espresso/latte/./././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/vietnamese",
+                "espresso/cappuccino/././././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/thai",
+                "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+        // bad source and bad destination
+        lfs_rename(&lfs,
+                "coffee/drip/./././././.",
+                "espresso/espresso/.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/././././.",
+                "espresso/americano/./.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/turkish/./././.",
+                "espresso/macchiato/././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/tubruk/././.",
+                "espresso/latte/./././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/./.",
+                "espresso/cappuccino/././././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/thai/.",
+                "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+    } else {
+        // bad source
+        lfs_rename(&lfs,
+                "coffee/drip/./././././.",
+                "espresso/espresso") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/././././.",
+                "espresso/americano") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish/./././.",
+                "espresso/macchiato") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk/././.",
+                "espresso/latte") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/./.",
+                "espresso/cappuccino") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/.",
+                "espresso/mocha") => LFS_ERR_NOTDIR;
+
+        // bad destination
+        lfs_rename(&lfs,
+                "coffee/drip",
+                "espresso/espresso/.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/coldbrew",
+                "espresso/americano/./.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/turkish",
+                "espresso/macchiato/././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/tubruk",
+                "espresso/latte/./././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/vietnamese",
+                "espresso/cappuccino/././././.") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/thai",
+                "espresso/mocha/./././././.") => LFS_ERR_NOENT;
+
+        // bad source and bad destination
+        lfs_rename(&lfs,
+                "coffee/drip/./././././.",
+                "espresso/espresso/.") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/././././.",
+                "espresso/americano/./.") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish/./././.",
+                "espresso/macchiato/././.") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk/././.",
+                "espresso/latte/./././.") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/./.",
+                "espresso/cappuccino/././././.") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/.",
+                "espresso/mocha/./././././.") => LFS_ERR_NOTDIR;
+    }
+
+    // remove paths
+    if (DIR) {
+        lfs_remove(&lfs, "coffee/drip/.") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/coldbrew/./.") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/turkish/././.") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/tubruk/./././.") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/vietnamese/././././.") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/thai/./././././.") => LFS_ERR_INVAL;
+    } else {
+        lfs_remove(&lfs, "coffee/drip/.") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/coldbrew/./.") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/turkish/././.") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/tubruk/./././.") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/vietnamese/././././.") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/thai/./././././.") => LFS_ERR_NOTDIR;
+    }
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
 
 # dot dot path tests
 [cases.test_paths_dotdots]
@@ -953,7 +1575,325 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
-# TODO test trailing dotdots
+# test trailing dot dots, these get really weird
+[cases.test_paths_trailing_dotdots]
+defines.DIR = [false, true]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    // create paths
+    lfs_mkdir(&lfs, "coffee") => 0;
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip/..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/coldbrew/../..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/turkish/../../..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_NOENT;
+        lfs_mkdir(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_NOENT;
+
+        // still create so we have something to test
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+        lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_NOENT;
+
+        // still create so we have something to test
+        lfs_file_open(&lfs, &file, "coffee/drip",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    // stat paths
+    struct lfs_info info;
+    if (DIR) {
+        lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => 0;
+        assert(strcmp(info.name, "/") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => 0;
+        assert(strcmp(info.name, "/") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => 0;
+        assert(strcmp(info.name, "/") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => 0;
+        assert(strcmp(info.name, "/") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => 0;
+        assert(strcmp(info.name, "/") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+        lfs_stat(&lfs, "coffee/thai/..", &info) => 0;
+        assert(strcmp(info.name, "coffee") == 0);
+        assert(info.type == LFS_TYPE_DIR);
+    } else {
+        lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => LFS_ERR_NOTDIR;
+        lfs_stat(&lfs, "coffee/thai/..", &info) => LFS_ERR_NOTDIR;
+    }
+
+    // file open paths, only works on files!
+    if (DIR) {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+                LFS_O_RDONLY) => LFS_ERR_ISDIR;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip/..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+        lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
+                LFS_O_RDONLY) => LFS_ERR_NOTDIR;
+    }
+
+    // dir open paths, only works on dirs!
+    if (DIR) {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+        lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => 0;
+        lfs_dir_close(&lfs, &dir) => 0;
+    } else {
+        lfs_dir_t dir;
+        lfs_dir_open(&lfs, &dir, "coffee/drip/..") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => LFS_ERR_NOTDIR;
+        lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => LFS_ERR_NOTDIR;
+    }
+
+    // rename paths
+    lfs_mkdir(&lfs, "espresso") => 0;
+    if (DIR) {
+        // bad source
+        lfs_rename(&lfs,
+                "coffee/drip/../../../../../..",
+                "espresso/espresso") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/../../../../..",
+                "espresso/americano") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/turkish/../../../..",
+                "espresso/macchiato") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/tubruk/../../..",
+                "espresso/latte") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/../..",
+                "espresso/cappuccino") => LFS_ERR_INVAL;
+        lfs_rename(&lfs,
+                "coffee/thai/..",
+                "espresso/mocha") => LFS_ERR_INVAL;
+
+        // bad destination
+        lfs_rename(&lfs,
+                "coffee/drip",
+                "espresso/espresso/..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/coldbrew",
+                "espresso/americano/../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/turkish",
+                "espresso/macchiato/../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/tubruk",
+                "espresso/latte/../../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/vietnamese",
+                "espresso/cappuccino/../../../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/thai",
+                "espresso/mocha/../../../../../..") => LFS_ERR_NOENT;
+
+        // bad source and bad destination
+        lfs_rename(&lfs,
+                "coffee/drip/../../../../../..",
+                "espresso/espresso/..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/../../../../..",
+                "espresso/americano/../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/turkish/../../../..",
+                "espresso/macchiato/../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/tubruk/../../..",
+                "espresso/latte/../../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/../..",
+                "espresso/cappuccino/../../../../..") => LFS_ERR_NOENT;
+        lfs_rename(&lfs,
+                "coffee/thai/..",
+                "espresso/mocha/../../../../../..") => LFS_ERR_NOENT;
+
+    } else {
+        // bad source
+        lfs_rename(&lfs,
+                "coffee/drip/../../../../../..",
+                "espresso/espresso") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/../../../../..",
+                "espresso/americano") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish/../../../..",
+                "espresso/macchiato") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk/../../..",
+                "espresso/latte") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/../..",
+                "espresso/cappuccino") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/..",
+                "espresso/mocha") => LFS_ERR_NOTDIR;
+
+        // bad destination
+        lfs_rename(&lfs,
+                "coffee/drip",
+                "espresso/espresso/..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew",
+                "espresso/americano/../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish",
+                "espresso/macchiato/../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk",
+                "espresso/latte/../../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese",
+                "espresso/cappuccino/../../../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai",
+                "espresso/mocha/../../../../../..") => LFS_ERR_NOTDIR;
+
+        // bad source and bad destination
+        lfs_rename(&lfs,
+                "coffee/drip/../../../../../..",
+                "espresso/espresso/..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/coldbrew/../../../../..",
+                "espresso/americano/../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/turkish/../../../..",
+                "espresso/macchiato/../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/tubruk/../../..",
+                "espresso/latte/../../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/vietnamese/../..",
+                "espresso/cappuccino/../../../../..") => LFS_ERR_NOTDIR;
+        lfs_rename(&lfs,
+                "coffee/thai/..",
+                "espresso/mocha/../../../../../..") => LFS_ERR_NOTDIR;
+    }
+
+    // remove paths
+    if (DIR) {
+        lfs_remove(&lfs, "coffee/drip/..") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/coldbrew/../..") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/turkish/../../..") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_INVAL;
+        lfs_remove(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_INVAL;
+    } else {
+        lfs_remove(&lfs, "coffee/drip/..") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/coldbrew/../..") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/turkish/../../..") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_NOTDIR;
+        lfs_remove(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_NOTDIR;
+    }
+
+    // stat paths
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+
+    lfs_unmount(&lfs) => 0;
+'''
 
 # dot dot dot path tests
 [cases.test_paths_dotdotdots]

--- a/tests/test_paths.toml
+++ b/tests/test_paths.toml
@@ -1643,10 +1643,10 @@ code = '''
     if (DIR) {
         lfs_mkdir(&lfs, "coffee/drip/..") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "coffee/coldbrew/../..") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "coffee/turkish/../../..") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_EXIST;
+        lfs_mkdir(&lfs, "coffee/turkish/../../..") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "coffee/tubruk/../../../..") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "coffee/vietnamese/../../../../..") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "coffee/thai/../../../../../..") => LFS_ERR_INVAL;
 
         // still create so we have something to test
         lfs_mkdir(&lfs, "coffee/drip") => 0;
@@ -1663,13 +1663,13 @@ code = '''
         lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
         lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_EXIST;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
 
         // still create so we have something to test
         lfs_file_open(&lfs, &file, "coffee/drip",
@@ -1694,18 +1694,10 @@ code = '''
 
     // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
+    lfs_stat(&lfs, "coffee/drip/../../../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/coldbrew/../../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/turkish/../../../..", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "coffee/tubruk/../../..", &info) => LFS_ERR_INVAL;
     lfs_stat(&lfs, "coffee/vietnamese/../..", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
@@ -1720,13 +1712,13 @@ code = '''
     lfs_file_open(&lfs, &file, "coffee/coldbrew/../..",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, "coffee/turkish/../../..",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
     lfs_file_open(&lfs, &file, "coffee/tubruk/../../../..",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
     lfs_file_open(&lfs, &file, "coffee/vietnamese/../../../../..",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
     lfs_file_open(&lfs, &file, "coffee/thai/../../../../../..",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
 
     // dir open paths, only works on dirs!
     lfs_dir_t dir;
@@ -1734,14 +1726,10 @@ code = '''
     lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, "coffee/coldbrew/../..") => 0;
     lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
+    lfs_dir_open(&lfs, &dir, "coffee/turkish/../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/tubruk/../../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/vietnamese/../../../../..") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "coffee/thai/../../../../../..") => LFS_ERR_INVAL;
 
     // rename paths
     lfs_mkdir(&lfs, "espresso") => 0;
@@ -2249,180 +2237,207 @@ code = '''
     lfs_mkdir(&lfs, "no") => 0;
     lfs_mkdir(&lfs, "coffee") => 0;
     if (DIR) {
-        lfs_mkdir(&lfs, "/../coffee/drip") => 0;
-        lfs_mkdir(&lfs, "/../../coffee/coldbrew") => 0;
-        lfs_mkdir(&lfs, "/../../../coffee/turkish") => 0;
-        lfs_mkdir(&lfs, "/no/../../coffee/tubruk") => 0;
-        lfs_mkdir(&lfs, "/no/../../../coffee/vietnamese") => 0;
-        lfs_mkdir(&lfs, "/no/../../../../coffee/thai") => 0;
+        lfs_mkdir(&lfs, "/../coffee/drip") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "/../../coffee/coldbrew") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "/../../../coffee/turkish") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "/no/../../coffee/tubruk") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "/no/../../../coffee/vietnamese") => LFS_ERR_INVAL;
+        lfs_mkdir(&lfs, "/no/../../../../coffee/thai") => LFS_ERR_INVAL;
     } else {
         lfs_file_t file;
         lfs_file_open(&lfs, &file, "/../coffee/drip",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
-        lfs_file_close(&lfs, &file) => 0;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
-        lfs_file_close(&lfs, &file) => 0;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
-        lfs_file_close(&lfs, &file) => 0;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
-                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
-        lfs_file_close(&lfs, &file) => 0;
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
         lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => LFS_ERR_INVAL;
+    }
+
+    // ok, actually create paths
+    if (DIR) {
+        lfs_mkdir(&lfs, "coffee/drip") => 0;
+        lfs_mkdir(&lfs, "coffee/coldbrew") => 0;
+        lfs_mkdir(&lfs, "coffee/turkish") => 0;
+        lfs_mkdir(&lfs, "coffee/tubruk") => 0;
+        lfs_mkdir(&lfs, "coffee/vietnamese") => 0;
+        lfs_mkdir(&lfs, "coffee/thai") => 0;
+    } else {
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, "coffee/drip",
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
         lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+        lfs_file_open(&lfs, &file, "coffee/coldbrew",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/turkish",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/tubruk",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/vietnamese",
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        lfs_file_open(&lfs, &file, "coffee/thai",
                 LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
         lfs_file_close(&lfs, &file) => 0;
     }
 
     // stat paths
     struct lfs_info info;
-    lfs_stat(&lfs, "/no/../../../../coffee/drip", &info) => 0;
-    assert(strcmp(info.name, "drip") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/no/../../../coffee/coldbrew", &info) => 0;
-    assert(strcmp(info.name, "coldbrew") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/no/../../coffee/turkish", &info) => 0;
-    assert(strcmp(info.name, "turkish") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../../../coffee/tubruk", &info) => 0;
-    assert(strcmp(info.name, "tubruk") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../../coffee/vietnamese", &info) => 0;
-    assert(strcmp(info.name, "vietnamese") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../coffee/thai", &info) => 0;
-    assert(strcmp(info.name, "thai") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "/no/../../../../coffee/drip", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "/no/../../../coffee/coldbrew", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "/no/../../coffee/turkish", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "/../../../coffee/tubruk", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "/../../coffee/vietnamese", &info) => LFS_ERR_INVAL;
+    lfs_stat(&lfs, "/../coffee/thai", &info) => LFS_ERR_INVAL;
 
     // file open paths, only works on files!
-    if (DIR) {
-        lfs_file_t file;
-        lfs_file_open(&lfs, &file, "/../coffee/drip",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
-                LFS_O_RDONLY) => LFS_ERR_ISDIR;
-    } else {
-        lfs_file_t file;
-        lfs_file_open(&lfs, &file, "/../coffee/drip",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-        lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
-                LFS_O_RDONLY) => 0;
-        lfs_file_close(&lfs, &file) => 0;
-    }
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "/../coffee/drip",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../coffee/coldbrew",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/../../../coffee/turkish",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../coffee/tubruk",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../coffee/vietnamese",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
+    lfs_file_open(&lfs, &file, "/no/../../../../coffee/thai",
+            LFS_O_RDONLY) => LFS_ERR_INVAL;
 
     // dir open paths, only works on dirs!
-    if (DIR) {
-        lfs_dir_t dir;
-        lfs_dir_open(&lfs, &dir, "/../coffee/drip") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "/../../coffee/coldbrew") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "/../../../coffee/turkish") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "/no/../../coffee/tubruk") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "/no/../../../coffee/vietnamese") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-        lfs_dir_open(&lfs, &dir, "/no/../../../../coffee/thai") => 0;
-        lfs_dir_close(&lfs, &dir) => 0;
-    } else {
-        lfs_dir_t dir;
-        lfs_dir_open(&lfs, &dir, "/../coffee/drip") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "/../../coffee/coldbrew") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "/../../../coffee/turkish") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "/no/../coffee/tubruk") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "/no/../../coffee/vietnamese") => LFS_ERR_NOTDIR;
-        lfs_dir_open(&lfs, &dir, "/no/../../../coffee/thai") => LFS_ERR_NOTDIR;
-    }
+    lfs_dir_t dir;
+    lfs_dir_open(&lfs, &dir, "/../coffee/drip") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "/../../coffee/coldbrew") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "/../../../coffee/turkish") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "/no/../../coffee/tubruk") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "/no/../../../coffee/vietnamese") => LFS_ERR_INVAL;
+    lfs_dir_open(&lfs, &dir, "/no/../../../../coffee/thai") => LFS_ERR_INVAL;
 
     // rename paths
     lfs_mkdir(&lfs, "espresso") => 0;
+    // bad source
     lfs_rename(&lfs,
             "/no/../../../../coffee/drip",
-            "/../espresso/espresso") => 0;
+            "espresso/espresso") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
             "/no/../../../coffee/coldbrew",
-            "/../../espresso/americano") => 0;
+            "espresso/americano") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
             "/no/../../coffee/turkish",
-            "/../../../espresso/macchiato") => 0;
+            "espresso/macchiato") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
             "/../../../coffee/tubruk",
-            "/no/../../espresso/latte") => 0;
+            "espresso/latte") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
             "/../../coffee/vietnamese",
-            "/no/../../../espresso/cappuccino") => 0;
+            "espresso/cappuccino") => LFS_ERR_INVAL;
     lfs_rename(&lfs,
             "/../coffee/thai",
-            "/no/../../../../espresso/mocha") => 0;
+            "espresso/mocha") => LFS_ERR_INVAL;
 
-    // stat paths
-    lfs_stat(&lfs, "/no/../../../../espresso/espresso", &info) => 0;
-    assert(strcmp(info.name, "espresso") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/no/../../../espresso/americano", &info) => 0;
-    assert(strcmp(info.name, "americano") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/no/../../espresso/macchiato", &info) => 0;
-    assert(strcmp(info.name, "macchiato") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../../../espresso/latte", &info) => 0;
-    assert(strcmp(info.name, "latte") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../../espresso/cappuccino", &info) => 0;
-    assert(strcmp(info.name, "cappuccino") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
-    lfs_stat(&lfs, "/../espresso/mocha", &info) => 0;
-    assert(strcmp(info.name, "mocha") == 0);
-    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    // bad destination
+    lfs_rename(&lfs,
+            "coffee/drip",
+            "/../espresso/espresso") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/coldbrew",
+            "/../../espresso/americano") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/turkish",
+            "/../../../espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/tubruk",
+            "/no/../../espresso/latte") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/vietnamese",
+            "/no/../../../espresso/cappuccino") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "coffee/thai",
+            "/no/../../../../espresso/mocha") => LFS_ERR_INVAL;
 
-    lfs_stat(&lfs, "/no/../../../../coffee/drip", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/no/../../../coffee/coldbrew", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/no/../../coffee/turkish", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../../../coffee/tubruk", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../../coffee/vietnamese", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../coffee/thai", &info) => LFS_ERR_NOENT;
+    // bad source and bad destination
+    lfs_rename(&lfs,
+            "/no/../../../../coffee/drip",
+            "/../espresso/espresso") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/no/../../../coffee/coldbrew",
+            "/../../espresso/americano") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/no/../../coffee/turkish",
+            "/../../../espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/../../../coffee/tubruk",
+            "/no/../../espresso/latte") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/../../coffee/vietnamese",
+            "/no/../../../espresso/cappuccino") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/../coffee/thai",
+            "/no/../../../../espresso/mocha") => LFS_ERR_INVAL;
+
+    // here's a weird one, what happens if our rename is also a noop?
+    lfs_rename(&lfs,
+            "/../coffee/drip",
+            "/../espresso/espresso") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/../../coffee/coldbrew",
+            "/../../espresso/americano") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/../../../coffee/turkish",
+            "/../../../espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/no/../../coffee/tubruk",
+            "/no/../../espresso/latte") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/no/../../../coffee/vietnamese",
+            "/no/../../../espresso/cappuccino") => LFS_ERR_INVAL;
+    lfs_rename(&lfs,
+            "/no/../../../../coffee/thai",
+            "/no/../../../../espresso/mocha") => LFS_ERR_INVAL;
 
     // remove paths
-    lfs_remove(&lfs, "/../espresso/espresso") => 0;
-    lfs_remove(&lfs, "/../../espresso/americano") => 0;
-    lfs_remove(&lfs, "/../../../espresso/macchiato") => 0;
-    lfs_remove(&lfs, "/no/../../espresso/latte") => 0;
-    lfs_remove(&lfs, "/no/../../../espresso/cappuccino") => 0;
-    lfs_remove(&lfs, "/no/../../../../espresso/mocha") => 0;
+    lfs_remove(&lfs, "/../espresso/espresso") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/../../espresso/americano") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/../../../espresso/macchiato") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/no/../../espresso/latte") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/no/../../../espresso/cappuccino") => LFS_ERR_INVAL;
+    lfs_remove(&lfs, "/no/../../../../espresso/mocha") => LFS_ERR_INVAL;
 
     // stat paths
-    lfs_stat(&lfs, "/no/../../../../espresso/espresso", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/no/../../../espresso/americano", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/no/../../espresso/macchiato", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../../../espresso/latte", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../../espresso/cappuccino", &info) => LFS_ERR_NOENT;
-    lfs_stat(&lfs, "/../espresso/mocha", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/espresso", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/americano", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/macchiato", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/latte", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/cappuccino", &info) => LFS_ERR_NOENT;
+    lfs_stat(&lfs, "espresso/mocha", &info) => LFS_ERR_NOENT;
+
+    lfs_stat(&lfs, "coffee/drip", &info) => 0;
+    assert(strcmp(info.name, "drip") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/coldbrew", &info) => 0;
+    assert(strcmp(info.name, "coldbrew") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/turkish", &info) => 0;
+    assert(strcmp(info.name, "turkish") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/tubruk", &info) => 0;
+    assert(strcmp(info.name, "tubruk") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/vietnamese", &info) => 0;
+    assert(strcmp(info.name, "vietnamese") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
+    lfs_stat(&lfs, "coffee/thai", &info) => 0;
+    assert(strcmp(info.name, "thai") == 0);
+    assert(info.type == ((DIR) ? LFS_TYPE_DIR : LFS_TYPE_REG));
 
     lfs_unmount(&lfs) => 0;
 '''
@@ -3089,7 +3104,6 @@ code = '''
         lfs_mkdir(&lfs, "/") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, ".") => LFS_ERR_EXIST;
-        lfs_mkdir(&lfs, "..") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "./") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "/.") => LFS_ERR_EXIST;
         lfs_mkdir(&lfs, "//") => LFS_ERR_EXIST;
@@ -3100,8 +3114,6 @@ code = '''
         lfs_file_open(&lfs, &file, "",
                 LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, ".",
-                LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
-        lfs_file_open(&lfs, &file, "..",
                 LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
         lfs_file_open(&lfs, &file, "./",
                 LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_ISDIR;
@@ -3119,9 +3131,6 @@ code = '''
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, ".", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "..", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, "./", &info) => 0;
@@ -3142,8 +3151,6 @@ code = '''
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, ".",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
-    lfs_file_open(&lfs, &file, "..",
-            LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, "./",
             LFS_O_RDONLY) => LFS_ERR_ISDIR;
     lfs_file_open(&lfs, &file, "/.",
@@ -3159,8 +3166,6 @@ code = '''
     lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, ".") => 0;
     lfs_dir_close(&lfs, &dir) => 0;
-    lfs_dir_open(&lfs, &dir, "..") => 0;
-    lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, "./") => 0;
     lfs_dir_close(&lfs, &dir) => 0;
     lfs_dir_open(&lfs, &dir, "/.") => 0;
@@ -3172,7 +3177,6 @@ code = '''
     lfs_rename(&lfs, "/", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, ".", "coffee") => LFS_ERR_INVAL;
-    lfs_rename(&lfs, "..", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "./", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "/.", "coffee") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "//", "coffee") => LFS_ERR_INVAL;
@@ -3181,7 +3185,6 @@ code = '''
     lfs_rename(&lfs, "coffee", "/") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", ".") => LFS_ERR_INVAL;
-    lfs_rename(&lfs, "coffee", "..") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "./") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "/.") => LFS_ERR_INVAL;
     lfs_rename(&lfs, "coffee", "//") => LFS_ERR_INVAL;
@@ -3205,9 +3208,6 @@ code = '''
     lfs_stat(&lfs, ".", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "..", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, "./", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
@@ -3222,7 +3222,6 @@ code = '''
     lfs_remove(&lfs, "/") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "") => LFS_ERR_INVAL;
     lfs_remove(&lfs, ".") => LFS_ERR_INVAL;
-    lfs_remove(&lfs, "..") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "./") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "/.") => LFS_ERR_INVAL;
     lfs_remove(&lfs, "//") => LFS_ERR_INVAL;
@@ -3235,9 +3234,6 @@ code = '''
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, ".", &info) => 0;
-    assert(strcmp(info.name, "/") == 0);
-    assert(info.type == LFS_TYPE_DIR);
-    lfs_stat(&lfs, "..", &info) => 0;
     assert(strcmp(info.name, "/") == 0);
     assert(info.type == LFS_TYPE_DIR);
     lfs_stat(&lfs, "./", &info) => 0;

--- a/tests/test_relocations.toml
+++ b/tests/test_relocations.toml
@@ -341,3 +341,171 @@ code = '''
     }
     lfs_unmount(&lfs) => 0;
 '''
+
+# non-reentrant testing for orphans, this is the same as reentrant
+# testing, but we test way more states than we could under powerloss
+[cases.test_relocations_nonreentrant]
+# TODO fix this case, caused by non-DAG trees
+# NOTE the second condition is required
+if = '!(DEPTH == 3 && CACHE_SIZE != 64) && 2*FILES < BLOCK_COUNT'
+defines = [
+    {FILES=6,  DEPTH=1, CYCLES=2000, BLOCK_CYCLES=1},
+    {FILES=26, DEPTH=1, CYCLES=2000, BLOCK_CYCLES=1},
+    {FILES=3,  DEPTH=3, CYCLES=2000, BLOCK_CYCLES=1},
+]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    uint32_t prng = 1;
+    const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+    for (unsigned i = 0; i < CYCLES; i++) {
+        // create random path
+        char full_path[256];
+        for (unsigned d = 0; d < DEPTH; d++) {
+            sprintf(&full_path[2*d], "/%c", alpha[TEST_PRNG(&prng) % FILES]);
+        }
+
+        // if it does not exist, we create it, else we destroy
+        struct lfs_info info;
+        int res = lfs_stat(&lfs, full_path, &info);
+        if (res == LFS_ERR_NOENT) {
+            // create each directory in turn, ignore if dir already exists
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                int err = lfs_mkdir(&lfs, path);
+                assert(!err || err == LFS_ERR_EXIST);
+            }
+
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                lfs_stat(&lfs, path, &info) => 0;
+                assert(strcmp(info.name, &path[2*d+1]) == 0);
+                assert(info.type == LFS_TYPE_DIR);
+            }
+        } else {
+            // is valid dir?
+            assert(strcmp(info.name, &full_path[2*(DEPTH-1)+1]) == 0);
+            assert(info.type == LFS_TYPE_DIR);
+
+            // try to delete path in reverse order, ignore if dir is not empty
+            for (unsigned d = DEPTH-1; d+1 > 0; d--) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                int err = lfs_remove(&lfs, path);
+                assert(!err || err == LFS_ERR_NOTEMPTY);
+            }
+
+            lfs_stat(&lfs, full_path, &info) => LFS_ERR_NOENT;
+        }
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
+# non-reentrant testing for relocations, but now with random renames!
+[cases.test_relocations_nonreentrant_renames]
+# TODO fix this case, caused by non-DAG trees
+# NOTE the second condition is required
+if = '!(DEPTH == 3 && CACHE_SIZE != 64) && 2*FILES < BLOCK_COUNT'
+defines = [
+    {FILES=6,  DEPTH=1, CYCLES=2000, BLOCK_CYCLES=1},
+    {FILES=26, DEPTH=1, CYCLES=2000, BLOCK_CYCLES=1},
+    {FILES=3,  DEPTH=3, CYCLES=2000, BLOCK_CYCLES=1},
+]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+
+    uint32_t prng = 1;
+    const char alpha[] = "abcdefghijklmnopqrstuvwxyz";
+    for (unsigned i = 0; i < CYCLES; i++) {
+        // create random path
+        char full_path[256];
+        for (unsigned d = 0; d < DEPTH; d++) {
+            sprintf(&full_path[2*d], "/%c", alpha[TEST_PRNG(&prng) % FILES]);
+        }
+
+        // if it does not exist, we create it, else we destroy
+        struct lfs_info info;
+        int res = lfs_stat(&lfs, full_path, &info);
+        assert(!res || res == LFS_ERR_NOENT);
+        if (res == LFS_ERR_NOENT) {
+            // create each directory in turn, ignore if dir already exists
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                int err = lfs_mkdir(&lfs, path);
+                assert(!err || err == LFS_ERR_EXIST);
+            }
+
+            for (unsigned d = 0; d < DEPTH; d++) {
+                char path[1024];
+                strcpy(path, full_path);
+                path[2*d+2] = '\0';
+                lfs_stat(&lfs, path, &info) => 0;
+                assert(strcmp(info.name, &path[2*d+1]) == 0);
+                assert(info.type == LFS_TYPE_DIR);
+            }
+        } else {
+            assert(strcmp(info.name, &full_path[2*(DEPTH-1)+1]) == 0);
+            assert(info.type == LFS_TYPE_DIR);
+
+            // create new random path
+            char new_path[256];
+            for (unsigned d = 0; d < DEPTH; d++) {
+                sprintf(&new_path[2*d], "/%c", alpha[TEST_PRNG(&prng) % FILES]);
+            }
+
+            // if new path does not exist, rename, otherwise destroy
+            res = lfs_stat(&lfs, new_path, &info);
+            assert(!res || res == LFS_ERR_NOENT);
+            if (res == LFS_ERR_NOENT) {
+                // stop once some dir is renamed
+                for (unsigned d = 0; d < DEPTH; d++) {
+                    char path[1024];
+                    strcpy(&path[2*d], &full_path[2*d]);
+                    path[2*d+2] = '\0';
+                    strcpy(&path[128+2*d], &new_path[2*d]);
+                    path[128+2*d+2] = '\0';
+                    int err = lfs_rename(&lfs, path, path+128);
+                    assert(!err || err == LFS_ERR_NOTEMPTY);
+                    if (!err) {
+                        strcpy(path, path+128);
+                    }
+                }
+
+                for (unsigned d = 0; d < DEPTH; d++) {
+                    char path[1024];
+                    strcpy(path, new_path);
+                    path[2*d+2] = '\0';
+                    lfs_stat(&lfs, path, &info) => 0;
+                    assert(strcmp(info.name, &path[2*d+1]) == 0);
+                    assert(info.type == LFS_TYPE_DIR);
+                }
+
+                lfs_stat(&lfs, full_path, &info) => LFS_ERR_NOENT;
+            } else {
+                // try to delete path in reverse order,
+                // ignore if dir is not empty
+                for (unsigned d = DEPTH-1; d+1 > 0; d--) {
+                    char path[1024];
+                    strcpy(path, full_path);
+                    path[2*d+2] = '\0';
+                    int err = lfs_remove(&lfs, path);
+                    assert(!err || err == LFS_ERR_NOTEMPTY);
+                }
+
+                lfs_stat(&lfs, full_path, &info) => LFS_ERR_NOENT;
+            }
+        }
+    }
+    lfs_unmount(&lfs) => 0;
+'''

--- a/tests/test_seek.toml
+++ b/tests/test_seek.toml
@@ -137,6 +137,130 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
+# boundary seek and reads
+[cases.test_seek_boundary_read]
+defines.COUNT = 132
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "kitty",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
+    size_t size = strlen("kittycatcat");
+    uint8_t buffer[1024];
+    memcpy(buffer, "kittycatcat", size);
+    for (int j = 0; j < COUNT; j++) {
+        lfs_file_write(&lfs, &file, buffer, size);
+    }
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_file_open(&lfs, &file, "kitty", LFS_O_RDONLY) => 0;
+
+    size = strlen("kittycatcat");
+    const lfs_soff_t offsets[] = {
+        512,
+        1024-4,
+        512+1,
+        1024-4+1,
+        512-1,
+        1024-4-1,
+
+        512-strlen("kittycatcat"),
+        1024-4-strlen("kittycatcat"),
+        512-strlen("kittycatcat")+1,
+        1024-4-strlen("kittycatcat")+1,
+        512-strlen("kittycatcat")-1,
+        1024-4-strlen("kittycatcat")-1,
+
+        strlen("kittycatcat")*(COUNT-2)-1,
+    };
+
+    for (unsigned i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
+        lfs_soff_t off = offsets[i];
+        // read @ offset
+        lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[off % strlen("kittycatcat")],
+                size) => 0;
+        // read after
+        lfs_file_seek(&lfs, &file, off+strlen("kittycatcat")+1, LFS_SEEK_SET)
+                => off+strlen("kittycatcat")+1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off+1) % strlen("kittycatcat")],
+                size) => 0;
+        // read before
+        lfs_file_seek(&lfs, &file, off-strlen("kittycatcat")-1, LFS_SEEK_SET)
+                => off-strlen("kittycatcat")-1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off-1) % strlen("kittycatcat")],
+                size) => 0;
+
+        // read @ 0
+        lfs_file_seek(&lfs, &file, 0, LFS_SEEK_SET) => 0;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer, "kittycatcat", size) => 0;
+
+        // read @ offset
+        lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[off % strlen("kittycatcat")],
+                size) => 0;
+        // read after
+        lfs_file_seek(&lfs, &file, off+strlen("kittycatcat")+1, LFS_SEEK_SET)
+                => off+strlen("kittycatcat")+1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off+1) % strlen("kittycatcat")],
+                size) => 0;
+        // read before
+        lfs_file_seek(&lfs, &file, off-strlen("kittycatcat")-1, LFS_SEEK_SET)
+                => off-strlen("kittycatcat")-1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off-1) % strlen("kittycatcat")],
+                size) => 0;
+
+        // sync
+        lfs_file_sync(&lfs, &file) => 0;
+
+        // read @ 0
+        lfs_file_seek(&lfs, &file, 0, LFS_SEEK_SET) => 0;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer, "kittycatcat", size) => 0;
+
+        // read @ offset
+        lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[off % strlen("kittycatcat")],
+                size) => 0;
+        // read after
+        lfs_file_seek(&lfs, &file, off+strlen("kittycatcat")+1, LFS_SEEK_SET)
+                => off+strlen("kittycatcat")+1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off+1) % strlen("kittycatcat")],
+                size) => 0;
+        // read before
+        lfs_file_seek(&lfs, &file, off-strlen("kittycatcat")-1, LFS_SEEK_SET)
+                => off-strlen("kittycatcat")-1;
+        lfs_file_read(&lfs, &file, buffer, size) => size;
+        memcmp(buffer,
+                &"kittycatcatkittycatcat"[(off-1) % strlen("kittycatcat")],
+                size) => 0;
+    }
+
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
 # boundary seek and writes
 [cases.test_seek_boundary_write]
 defines.COUNT = 132
@@ -160,31 +284,54 @@ code = '''
     lfs_file_open(&lfs, &file, "kitty", LFS_O_RDWR) => 0;
 
     size = strlen("hedgehoghog");
-    const lfs_soff_t offsets[] = {512, 1020, 513, 1021, 511, 1019, 1441};
+    const lfs_soff_t offsets[] = {
+        512,
+        1024-4,
+        512+1,
+        1024-4+1,
+        512-1,
+        1024-4-1,
+
+        512-strlen("kittycatcat"),
+        1024-4-strlen("kittycatcat"),
+        512-strlen("kittycatcat")+1,
+        1024-4-strlen("kittycatcat")+1,
+        512-strlen("kittycatcat")-1,
+        1024-4-strlen("kittycatcat")-1,
+
+        strlen("kittycatcat")*(COUNT-2)-1,
+    };
 
     for (unsigned i = 0; i < sizeof(offsets) / sizeof(offsets[0]); i++) {
         lfs_soff_t off = offsets[i];
+        // write @ offset
         memcpy(buffer, "hedgehoghog", size);
         lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
         lfs_file_write(&lfs, &file, buffer, size) => size;
+
+        // read @ offset
         lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
         lfs_file_read(&lfs, &file, buffer, size) => size;
         memcmp(buffer, "hedgehoghog", size) => 0;
 
+        // read @ 0
         lfs_file_seek(&lfs, &file, 0, LFS_SEEK_SET) => 0;
         lfs_file_read(&lfs, &file, buffer, size) => size;
         memcmp(buffer, "kittycatcat", size) => 0;
 
+        // read @ offset
         lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
         lfs_file_read(&lfs, &file, buffer, size) => size;
         memcmp(buffer, "hedgehoghog", size) => 0;
 
         lfs_file_sync(&lfs, &file) => 0;
 
+        // read @ 0
         lfs_file_seek(&lfs, &file, 0, LFS_SEEK_SET) => 0;
         lfs_file_read(&lfs, &file, buffer, size) => size;
         memcmp(buffer, "kittycatcat", size) => 0;
 
+        // read @ offset
         lfs_file_seek(&lfs, &file, off, LFS_SEEK_SET) => off;
         lfs_file_read(&lfs, &file, buffer, size) => size;
         memcmp(buffer, "hedgehoghog", size) => 0;

--- a/tests/test_seek.toml
+++ b/tests/test_seek.toml
@@ -405,3 +405,111 @@ code = '''
     lfs_file_close(&lfs, &file) => 0;
     lfs_unmount(&lfs) => 0;
 '''
+
+
+# test possible overflow/underflow conditions
+#
+# note these need -fsanitize=undefined to consistently detect
+# overflow/underflow conditions
+
+[cases.test_seek_filemax]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "kitty",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
+    uint8_t buffer[1024];
+    strcpy((char*)buffer, "kittycatcat");
+    size_t size = strlen((char*)buffer);
+    lfs_file_write(&lfs, &file, buffer, size) => size;
+
+    // seek with LFS_SEEK_SET
+    lfs_file_seek(&lfs, &file, LFS_FILE_MAX, LFS_SEEK_SET) => LFS_FILE_MAX;
+
+    // seek with LFS_SEEK_CUR
+    lfs_file_seek(&lfs, &file, 0, LFS_SEEK_CUR) => LFS_FILE_MAX;
+
+    // the file hasn't changed size, so seek end takes us back to the offset=0
+    lfs_file_seek(&lfs, &file, +10, LFS_SEEK_END) => size+10;
+
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
+[cases.test_seek_underflow]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "kitty",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
+    uint8_t buffer[1024];
+    strcpy((char*)buffer, "kittycatcat");
+    size_t size = strlen((char*)buffer);
+    lfs_file_write(&lfs, &file, buffer, size) => size;
+
+    // underflow with LFS_SEEK_CUR, should error
+    lfs_file_seek(&lfs, &file, -(size+10), LFS_SEEK_CUR) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, -LFS_FILE_MAX, LFS_SEEK_CUR) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, -(size+LFS_FILE_MAX), LFS_SEEK_CUR)
+            => LFS_ERR_INVAL;
+
+    // underflow with LFS_SEEK_END, should error
+    lfs_file_seek(&lfs, &file, -(size+10), LFS_SEEK_END) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, -LFS_FILE_MAX, LFS_SEEK_END) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, -(size+LFS_FILE_MAX), LFS_SEEK_END)
+            => LFS_ERR_INVAL;
+
+    // file pointer should not have changed
+    lfs_file_tell(&lfs, &file) => size;
+
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+'''
+
+[cases.test_seek_overflow]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "kitty",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_APPEND) => 0;
+    uint8_t buffer[1024];
+    strcpy((char*)buffer, "kittycatcat");
+    size_t size = strlen((char*)buffer);
+    lfs_file_write(&lfs, &file, buffer, size) => size;
+
+    // seek to LFS_FILE_MAX
+    lfs_file_seek(&lfs, &file, LFS_FILE_MAX, LFS_SEEK_SET) => LFS_FILE_MAX;
+
+    // overflow with LFS_SEEK_CUR, should error
+    lfs_file_seek(&lfs, &file, +10, LFS_SEEK_CUR) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, +LFS_FILE_MAX, LFS_SEEK_CUR) => LFS_ERR_INVAL;
+
+    // LFS_SEEK_SET/END don't care about the current file position, but we can
+    // still overflow with a large offset
+
+    // overflow with LFS_SEEK_SET, should error
+    lfs_file_seek(&lfs, &file,
+            +((uint32_t)LFS_FILE_MAX+10),
+            LFS_SEEK_SET) => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file,
+            +((uint32_t)LFS_FILE_MAX+(uint32_t)LFS_FILE_MAX),
+            LFS_SEEK_SET) => LFS_ERR_INVAL;
+
+    // overflow with LFS_SEEK_END, should error
+    lfs_file_seek(&lfs, &file, +(LFS_FILE_MAX-size+10), LFS_SEEK_END)
+            => LFS_ERR_INVAL;
+    lfs_file_seek(&lfs, &file, +(LFS_FILE_MAX-size+LFS_FILE_MAX), LFS_SEEK_END)
+            => LFS_ERR_INVAL;
+
+    // file pointer should not have changed
+    lfs_file_tell(&lfs, &file) => LFS_FILE_MAX;
+
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+'''

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -7,7 +7,7 @@ code = '''
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT) => 0;
+    lfs_fs_grow(&lfs, AFTER_BLOCK_COUNT) => 0;
     lfs_unmount(&lfs);
     if (BLOCK_COUNT != AFTER_BLOCK_COUNT) {
         lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
@@ -46,7 +46,7 @@ code = '''
         lfs_file_close(&lfs, &file) => 0;
     }
 
-    int err = lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT);
+    int err = lfs_fs_grow(&lfs, AFTER_BLOCK_COUNT);
     if (err == 0) {
         for (int i = 0; i < FILES_COUNT + 1; i++) {
             lfs_file_t file;

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -2,8 +2,10 @@
 [cases.test_shrink_simple]
 defines.BLOCK_COUNT = [10, 15, 20]
 defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
+   
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
@@ -18,6 +20,7 @@ code = '''
     lfs2.cfg = &cfg2;
     lfs_mount(&lfs2, &cfg2) => 0;
     lfs_unmount(&lfs2) => 0;
+#endif
 '''
 
 # shrinking full
@@ -27,6 +30,7 @@ defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
 defines.FILES_COUNT = [7, 8, 9, 10]
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)
@@ -101,4 +105,5 @@ code = '''
         }
         lfs_unmount(&lfs2);
     }
+#endif
 '''

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -5,7 +5,7 @@ defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
    
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     lfs_mount(&lfs, cfg) => 0;
@@ -30,7 +30,7 @@ defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
 defines.FILES_COUNT = [7, 8, 9, 10]
 if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
     // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)

--- a/tests/test_shrink.toml
+++ b/tests/test_shrink.toml
@@ -1,0 +1,104 @@
+# simple shrink
+[cases.test_shrink_simple]
+defines.BLOCK_COUNT = [10, 15, 20]
+defines.AFTER_BLOCK_COUNT = [5, 10, 15, 19]
+if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT"
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT) => 0;
+    lfs_unmount(&lfs);
+    if (BLOCK_COUNT != AFTER_BLOCK_COUNT) {
+        lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+    }
+    lfs_t lfs2 = lfs;
+    struct lfs_config cfg2 = *cfg;
+    cfg2.block_count = AFTER_BLOCK_COUNT;
+    lfs2.cfg = &cfg2;
+    lfs_mount(&lfs2, &cfg2) => 0;
+    lfs_unmount(&lfs2) => 0;
+'''
+
+# shrinking full
+[cases.test_shrink_full]
+defines.BLOCK_COUNT = [10, 15, 20]
+defines.AFTER_BLOCK_COUNT = [5, 7, 10, 12, 15, 17, 20]
+defines.FILES_COUNT = [7, 8, 9, 10]
+if = "AFTER_BLOCK_COUNT <= BLOCK_COUNT && FILES_COUNT + 2 < BLOCK_COUNT"
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    // create FILES_COUNT files of BLOCK_SIZE - 50 bytes (to avoid inlining)
+    lfs_mount(&lfs, cfg) => 0;
+    for (int i = 0; i < FILES_COUNT + 1; i++) {
+        lfs_file_t file;
+        char path[1024];
+        sprintf(path, "file_%03d", i);
+        lfs_file_open(&lfs, &file, path,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        char wbuffer[BLOCK_SIZE];
+        memset(wbuffer, 'b', BLOCK_SIZE);
+        // Ensure one block is taken per file, but that files are not inlined.
+        lfs_size_t size = BLOCK_SIZE - 0x40;
+        sprintf(wbuffer, "Hi %03d", i);
+        lfs_file_write(&lfs, &file, wbuffer, size) => size;
+        lfs_file_close(&lfs, &file) => 0;
+    }
+
+    int err = lfs_fs_shrink(&lfs, AFTER_BLOCK_COUNT);
+    if (err == 0) {
+        for (int i = 0; i < FILES_COUNT + 1; i++) {
+            lfs_file_t file;
+            char path[1024];
+            sprintf(path, "file_%03d", i);
+            lfs_file_open(&lfs, &file, path,
+                    LFS_O_RDONLY ) => 0;
+            lfs_size_t size = BLOCK_SIZE - 0x40;
+            char wbuffer[size];
+            char wbuffer_ref[size];
+            // Ensure one block is taken per file, but that files are not inlined.
+            memset(wbuffer_ref, 'b', size);
+            sprintf(wbuffer_ref, "Hi %03d", i);
+            lfs_file_read(&lfs, &file, wbuffer, BLOCK_SIZE) => size;
+            lfs_file_close(&lfs, &file) => 0;
+            for (lfs_size_t j = 0; j < size; j++) {
+                wbuffer[j] => wbuffer_ref[j];
+            }
+        }
+    } else {
+        assert(err == LFS_ERR_NOTEMPTY);
+    }
+
+    lfs_unmount(&lfs) => 0;
+    if (err == 0 ) {
+        if ( AFTER_BLOCK_COUNT != BLOCK_COUNT ) {
+            lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+        }
+
+        lfs_t lfs2 = lfs;
+        struct lfs_config cfg2 = *cfg;
+        cfg2.block_count = AFTER_BLOCK_COUNT;
+        lfs2.cfg = &cfg2;
+        lfs_mount(&lfs2, &cfg2) => 0;
+        for (int i = 0; i < FILES_COUNT + 1; i++) {
+            lfs_file_t file;
+            char path[1024];
+            sprintf(path, "file_%03d", i);
+            lfs_file_open(&lfs2, &file, path,
+                    LFS_O_RDONLY ) => 0;
+            lfs_size_t size = BLOCK_SIZE - 0x40;
+            char wbuffer[size];
+            char wbuffer_ref[size];
+            // Ensure one block is taken per file, but that files are not inlined.
+            memset(wbuffer_ref, 'b', size);
+            sprintf(wbuffer_ref, "Hi %03d", i);
+            lfs_file_read(&lfs2, &file, wbuffer, BLOCK_SIZE) => size;
+            lfs_file_close(&lfs2, &file) => 0;
+            for (lfs_size_t j = 0; j < size; j++) {
+                wbuffer[j] => wbuffer_ref[j];
+            }
+        }
+        lfs_unmount(&lfs2);
+    }
+'''

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -523,3 +523,30 @@ code = '''
     assert(memcmp(buffer, "hello!", 6) == 0);
     lfs_unmount(&lfs) => 0;
 '''
+
+# test that metadata_max does not cause problems for superblock compaction
+[cases.test_superblocks_metadata_max]
+defines.METADATA_MAX = [
+    'lfs_max(512, PROG_SIZE)',
+    'lfs_max(BLOCK_SIZE/2, PROG_SIZE)',
+    'BLOCK_SIZE'
+]
+defines.N = [10, 100, 1000]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    lfs_mount(&lfs, cfg) => 0;
+    for (int i = 0; i < N; i++) {
+        lfs_file_t file;
+        char name[256];
+        sprintf(name, "hello%03x", i);
+        lfs_file_open(&lfs, &file, name,
+                LFS_O_WRONLY | LFS_O_CREAT | LFS_O_EXCL) => 0;
+        lfs_file_close(&lfs, &file) => 0;
+        struct lfs_info info;
+        lfs_stat(&lfs, name, &info) => 0;
+        assert(strcmp(info.name, name) == 0);
+        assert(info.type == LFS_TYPE_REG);
+    }
+    lfs_unmount(&lfs) => 0;
+'''

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -531,7 +531,7 @@ defines.BLOCK_COUNT = 'ERASE_COUNT'
 defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
 defines.KNOWN_BLOCK_COUNT = [true, false]
 code = '''
-#ifdef LFS_SHRINKIFCHEAP
+#ifdef LFS_SHRINKNONRELOCATING
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
 

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -531,6 +531,7 @@ defines.BLOCK_COUNT = 'ERASE_COUNT'
 defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
 defines.KNOWN_BLOCK_COUNT = [true, false]
 code = '''
+#ifdef LFS_SHRINKIFCHEAP
     lfs_t lfs;
     lfs_format(&lfs, cfg) => 0;
 
@@ -628,6 +629,7 @@ code = '''
     lfs_file_close(&lfs, &file) => 0;
     assert(memcmp(buffer, "hello!", 6) == 0);
     lfs_unmount(&lfs) => 0;
+#endif
 '''
 
 # test that metadata_max does not cause problems for superblock compaction

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -550,7 +550,7 @@ code = '''
 
     // same size is a noop
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT);
@@ -564,7 +564,7 @@ code = '''
 
     // grow to new size
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT_2) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT_2);
@@ -594,7 +594,7 @@ code = '''
 
     // same size is a noop
     lfs_mount(&lfs, cfg) => 0;
-    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_grow(&lfs, BLOCK_COUNT_2) => 0;
     lfs_fs_stat(&lfs, &fsinfo) => 0;
     assert(fsinfo.block_size == BLOCK_SIZE);
     assert(fsinfo.block_count == BLOCK_COUNT_2);

--- a/tests/test_superblocks.toml
+++ b/tests/test_superblocks.toml
@@ -524,6 +524,112 @@ code = '''
     lfs_unmount(&lfs) => 0;
 '''
 
+
+# mount and grow the filesystem
+[cases.test_superblocks_shrink]
+defines.BLOCK_COUNT = 'ERASE_COUNT'
+defines.BLOCK_COUNT_2 = ['ERASE_COUNT/2', 'ERASE_COUNT/4', '2']
+defines.KNOWN_BLOCK_COUNT = [true, false]
+code = '''
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    // mount with block_size < erase_size
+    lfs_mount(&lfs, cfg) => 0;
+    struct lfs_fsinfo fsinfo;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    // same size is a noop
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT);
+    lfs_unmount(&lfs) => 0;
+
+    // grow to new size
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT_2;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    // mounting with the previous size should fail
+    cfg->block_count = BLOCK_COUNT;
+    lfs_mount(&lfs, cfg) => LFS_ERR_INVAL;
+
+    if (KNOWN_BLOCK_COUNT) {
+        cfg->block_count = BLOCK_COUNT_2;
+    } else {
+        cfg->block_count = 0;
+    }
+
+    // same size is a noop
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_shrink(&lfs, BLOCK_COUNT_2) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_unmount(&lfs) => 0;
+
+    // do some work
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_file_t file;
+    lfs_file_open(&lfs, &file, "test",
+            LFS_O_CREAT | LFS_O_EXCL | LFS_O_WRONLY) => 0;
+    lfs_file_write(&lfs, &file, "hello!", 6) => 6;
+    lfs_file_close(&lfs, &file) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    lfs_mount(&lfs, cfg) => 0;
+    lfs_fs_stat(&lfs, &fsinfo) => 0;
+    assert(fsinfo.block_size == BLOCK_SIZE);
+    assert(fsinfo.block_count == BLOCK_COUNT_2);
+    lfs_file_open(&lfs, &file, "test", LFS_O_RDONLY) => 0;
+    uint8_t buffer[256];
+    lfs_file_read(&lfs, &file, buffer, sizeof(buffer)) => 6;
+    lfs_file_close(&lfs, &file) => 0;
+    assert(memcmp(buffer, "hello!", 6) == 0);
+    lfs_unmount(&lfs) => 0;
+'''
+
 # test that metadata_max does not cause problems for superblock compaction
 [cases.test_superblocks_metadata_max]
 defines.METADATA_MAX = [


### PR DESCRIPTION
### 简单验证测试
- 可与V2.9.3保持兼容
```sh
System Clock information
SYSCLK_Frequency = 168000000 HCLK_Frequency   = 168000000
PCLK1_Frequency  = 42000000 PCLK2_Frequency  = 84000000
HAL version      = V1.8.5
GCC version      = 14.3.1

 \ | /
- RT -     Thread Operating System
 / | \     5.2.2 build Oct 20 2025 13:45:25
 2006 - 2024 Copyright by RT-Thread team
SFUD: Found a Winbond flash chip. Size is 8388608 bytes.
SFUD: norflash0 flash device initialized successfully.
SFUD: Probe SPI flash norflash0 by SPI device spi10 success.
FAL: Flash device |                norflash0 | addr: 0x00000000 | len: 0x00800000 | blk_size: 0x00001000 |initialized finish.
FAL: ==================== FAL partition table ====================
FAL: | name       | flash_dev |   offset   |    length  |
FAL: -------------------------------------------------------------
FAL: | filesystem | norflash0 | 0x00000000 | 0x00800000 |
FAL: =============================================================
FAL: RT-Thread Flash Abstraction Layer initialize success.
FAL: The FAL MTD NOR device (filesystem) created successfully
msh />app.filesystem: mount to '/flash' success!
msh />cd /f
msh />cd /flash/
msh /flash>ls
Directory /flash:
test                <DIR>                    
msh /flash>cd t
msh /flash>cd test/
msh /flash/test>cat h
msh /flash/test>cat h
msh /flash/test>cat he
msh /flash/test>ll    
ll: command not found.
msh /flash/test>ls
Directory /flash/test:
readme.md           11                       
msh /flash/test>cat re
msh /flash/test>cat readme.md
hello world
msh /flash/test>
```

<img width="471" height="426" alt="image" src="https://github.com/user-attachments/assets/c352a9f6-b6e6-4666-a25b-d3b57751e287" />



Littlefs 从 v2.9.9 到 v2.11.2 版本涵盖了多个更新，主要集中在 v2.10.x 和 v2.11.x 版本系列中。这些更新带来了重要的新功能、问题修复以及一些可能影响现有实现的重大变更。

### **v2.10 系列**

此系列版本主要围绕路径解析的重构和一些错误修复。

**v2.10.0**

*   **重大变更：**
    *   **路径解析：** 对路径解析进行了内部重构，使其在多种极端情况下更符合 POSIX 和用户的预期。 这改变了涉及尾部斜杠、在根目录之上导航以及空路径的行为。
*   **新功能：**
    *   **LFS_DEFINES：** 引入了 `LFS_DEFINES` 作为 `LFS_CONFIG` 的简化替代方案，方便用户部分覆盖 `lfs_util.h` 中的定义。
    *   **断言：** 如果块设备回调函数为 NULL，现在会触发断言。
*   **错误修复：**
    *   修复了在使用 `metadata_max` 时可能导致过早出现 `LFS_ERR_NOSPC`（无空间）错误的元数据压缩问题。
    *   通过去重 `lfs_tortoise_detectcycles` 函数优化了代码大小。

**v2.10.1**

*   **错误修复：**
    *   修复了在从块末尾寻址时可能导致缓存重用不正确的问题。

**v2.10.2**

*   **错误修复：**
    *   修复了与 MSVC 编译器一起使用时出现的“不安全使用布尔类型”的警告。
    *   解决了并发删除操作可能破坏目录迭代的问题。
    *   修复了在启用跟踪时文件大小的符号不匹配问题。

### **v2.11 系列**

v2.11 系列引入了对文件系统收缩的有限支持，并包含了一些重要的错误修复。此外，从 v2.11.1 版本开始，littlefs v2 进入了功能冻结状态，以便将开发重点转移到 v3 版本。

**v2.11.0**

*   **新功能：**
    *   **文件系统收缩：** 引入了 `LFS_SHRINKNONRELOCATING` 编译选项。 如果启用，`lfs_fs_grow` 函数可以用来减少文件系统的 `block_count`，前提是不需要进行块的重定位。 这对于从旧的文件系统镜像迁移非常有用。
    *   **macOS 支持：** `make test` 命令现在可以直接在 Mac 上运行。
    *   **Clang 编译器支持：** Makefile 现在支持使用 Clang 进行编译。
*   **错误修复：**
    *   修复了多个与 `LFS_CRC` 相关的错误。
    *   修复了在删除操作期间，当一个元数据目录（mdir）重定位时可能发生的双重孤立问题。
    *   解决了 `lfs_fromle32`/`lfs_frombe32` 函数在 16 位设备上可能出现的溢出风险。

**v2.11.1**

*   这是一个补丁版本，主要包含由社区贡献者提供的垃圾回收（GC）性能修复。

**v2.11.2**

*   这也是一个补丁版本，主要修复了以下问题：
    *   修复了反向的 `dir->count` 检查逻辑。
    *   在提交之前移动了 `dir->count` 检查，并将其限制为小于 `0xff`。
    *   修复了可能导致未初始化读取的缺失 `return` 的问题。