### PR TITLE
fix:重复打开文件出错

### DIFF
--- a/dfs_lfs.c
+++ b/dfs_lfs.c
@@ -576,7 +576,6 @@ static int _dfs_lfs_open(struct dfs_file* file)
             return -ENOENT;
         }
         file->pos = 0;
-        return 0;
     }
 
     dfs_lfs = (dfs_lfs_t*)dfs->data;
@@ -691,10 +690,6 @@ static int _dfs_lfs_close(struct dfs_file* file)
     RT_ASSERT(file->data != RT_NULL);
 
     RT_ASSERT(file->vnode->ref_count > 0);
-    if (file->vnode->ref_count > 1)
-    {
-        return 0;
-    }
 
     dfs_lfs_fd = (dfs_lfs_fd_t*)file->data;
 
@@ -714,6 +709,7 @@ static int _dfs_lfs_close(struct dfs_file* file)
     }
 
     rt_free(dfs_lfs_fd);
+    file->data = RT_NULL;
 
     return _lfs_result_to_dfs(result);
 }


### PR DESCRIPTION
- 修改前与https://github.com/RT-Thread-packages/littlefs/issues/26反馈现象一致
- 修改后可以正常cat读取,还在使用状态的文件
- 并且使用cat多次open/close后内存无增加