### PR TITLE
Merge tag 'v2.11.3'

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ More details on how littlefs works can be found in [DESIGN.md](DESIGN.md) and
 ## Testing
 
 The littlefs comes with a test suite designed to run on a PC using the
-[emulated block device](bd/lfs_testbd.h) found in the `bd` directory.
+[emulated block device](bd/lfs_emubd.h) found in the `bd` directory.
 The tests assume a Linux environment and can be started with make:
 
 ``` bash

--- a/lfs.c
+++ b/lfs.c
@@ -1290,7 +1290,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
             }
 
             // found a match for our fetcher?
-            if ((fmask & tag) == (fmask & ftag)) {
+            if ((fmask & tag) == (fmask & ftag) && (cb != NULL)) {
                 int res = cb(data, tag, &(struct lfs_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {

--- a/lfs.c
+++ b/lfs.c
@@ -286,7 +286,7 @@ static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
 
 // some operations on paths
 static inline lfs_size_t lfs_path_namelen(const char *path) {
-    return strcspn(path, "/");
+    return (lfs_size_t)strcspn(path, "/");
 }
 
 static inline bool lfs_path_islast(const char *path) {
@@ -1501,7 +1501,7 @@ nextname:
         if (lfs_tag_type3(tag) == LFS_TYPE_DIR) {
             name += strspn(name, "/");
         }
-        lfs_size_t namelen = strcspn(name, "/");
+        lfs_size_t namelen = (lfs_size_t)strcspn(name, "/");
 
         // skip '.'
         if (namelen == 1 && memcmp(name, ".", 1) == 0) {
@@ -1520,7 +1520,7 @@ nextname:
         int depth = 1;
         while (true) {
             suffix += strspn(suffix, "/");
-            sufflen = strcspn(suffix, "/");
+            sufflen = (lfs_size_t)strcspn(suffix, "/");
             if (sufflen == 0) {
                 break;
             }
@@ -1761,7 +1761,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
 
         commit->off = noff;
         // perturb valid bit?
-        commit->ptag = ntag ^ ((0x80UL & ~eperturb) << 24);
+        commit->ptag = ntag ^ ((lfs_tag_t)(0x80 & ~eperturb) << 24);
         // reset crc for next commit
         commit->crc = 0xffffffff;
 

--- a/lfs.c
+++ b/lfs.c
@@ -258,7 +258,7 @@ static int lfs_bd_prog(lfs_t *lfs,
             continue;
         }
 
-        // pcache must have been flushed, either by programming and
+        // pcache must have been flushed, either by programming an
         // entire block or manually flushing the pcache
         LFS_ASSERT(pcache->block == LFS_BLOCK_NULL);
 

--- a/lfs.c
+++ b/lfs.c
@@ -1290,7 +1290,8 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
             }
 
             // found a match for our fetcher?
-            if ((fmask & tag) == (fmask & ftag) && (cb != NULL)) {
+            if ((fmask & tag) == (fmask & ftag)) {
+                LFS_ASSERT(cb != NULL);
                 int res = cb(data, tag, &(struct lfs_diskoff){
                         dir->pair[0], off+sizeof(tag)});
                 if (res < 0) {

--- a/lfs.c
+++ b/lfs.c
@@ -3244,10 +3244,12 @@ static int lfs_file_open_(lfs_t *lfs, lfs_file_t *file,
 #endif
 
 static int lfs_file_close_(lfs_t *lfs, lfs_file_t *file) {
-#ifndef LFS_READONLY
-    int err = lfs_file_sync_(lfs, file);
-#else
     int err = 0;
+#ifndef LFS_READONLY
+    // it's not safe to do anything if our file errored
+    if (!(file->flags & LFS_F_ERRED)) {
+        err = lfs_file_sync_(lfs, file);
+    }
 #endif
 
     // remove from list of mdirs
@@ -3429,17 +3431,11 @@ relocate:
 
 #ifndef LFS_READONLY
 static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file) {
-    if (file->flags & LFS_F_ERRED) {
-        // it's not safe to do anything if our file errored
-        return 0;
-    }
-
     int err = lfs_file_flush(lfs, file);
     if (err) {
         file->flags |= LFS_F_ERRED;
         return err;
     }
-
 
     if ((file->flags & LFS_F_DIRTY) &&
             !lfs_pair_isnull(file->m.pair)) {
@@ -3485,6 +3481,17 @@ static int lfs_file_sync_(lfs_t *lfs, lfs_file_t *file) {
         file->flags &= ~LFS_F_DIRTY;
     }
 
+    // mark any other file handles as dirty + desync
+    for (lfs_file_t *f = (lfs_file_t*)lfs->mlist; f; f = f->next) {
+        if (file != f
+                && f->type == LFS_TYPE_REG
+                && lfs_pair_cmp(f->m.pair, file->m.pair) == 0
+                && f->id == file->id) {
+            f->flags |= LFS_F_DUSTY;
+        }
+    }
+
+    file->flags &= ~LFS_F_ERRED & ~LFS_F_DUSTY;
     return 0;
 }
 #endif
@@ -3692,7 +3699,7 @@ static lfs_ssize_t lfs_file_write_(lfs_t *lfs, lfs_file_t *file,
         return nsize;
     }
 
-    file->flags &= ~LFS_F_ERRED;
+    file->flags &= ~LFS_F_ERRED & ~LFS_F_DUSTY;
     return nsize;
 }
 #endif
@@ -4771,7 +4778,8 @@ int lfs_fs_traverse_(lfs_t *lfs,
             continue;
         }
 
-        if ((f->flags & LFS_F_DIRTY) && !(f->flags & LFS_F_INLINE)) {
+        if (((f->flags & LFS_F_DIRTY) || (f->flags & LFS_F_DUSTY))
+                && !(f->flags & LFS_F_INLINE)) {
             int err = lfs_ctz_traverse(lfs, &f->cache, &lfs->rcache,
                     f->ctz.head, f->ctz.size, cb, data);
             if (err) {

--- a/lfs.h
+++ b/lfs.h
@@ -135,14 +135,15 @@ enum lfs_open_flags {
 
     // internally used flags
 #ifndef LFS_READONLY
-    LFS_F_DIRTY   = 0x010000, // File does not match storage
-    LFS_F_WRITING = 0x020000, // File has been written since last flush
+    LFS_F_DIRTY   = 0x00010000, // File does not match storage due to write
+    LFS_F_DUSTY   = 0x00020000, // File does not match storage due to desync
+    LFS_F_WRITING = 0x00040000, // File has been written since last flush
 #endif
-    LFS_F_READING = 0x040000, // File has been read since last flush
+    LFS_F_READING = 0x00080000, // File has been read since last flush
 #ifndef LFS_READONLY
-    LFS_F_ERRED   = 0x080000, // An error occurred during write
+    LFS_F_ERRED   = 0x00100000, // An error occurred during write
 #endif
-    LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS_F_INLINE  = 0x01000000, // Currently inlined in directory entry
 };
 
 // File seek flags

--- a/tests/test_alloc.toml
+++ b/tests/test_alloc.toml
@@ -250,6 +250,189 @@ code = '''
     }
 '''
 
+# multiple handle allocation test
+#
+# this tests that multiple open handles to the same file don't clobber
+# each other
+[cases.test_alloc_multihandle]
+defines.FILES = 2
+defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / FILES)'
+defines.GC = [false, true]
+defines.COMPACT_THRESH = ['-1', '0', 'BLOCK_SIZE/2']
+defines.INFER_BC = [false, true]
+defines.SYNC = [false, true]
+code = '''
+    const char *names[] = {"eggs", "spinach"};
+    lfs_file_t files[FILES];
+
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    struct lfs_config cfg_ = *cfg;
+    if (INFER_BC) {
+        cfg_.block_count = 0;
+    }
+    lfs_mount(&lfs, &cfg_) => 0;
+    lfs_mkdir(&lfs, "breakfast") => 0;
+
+    // write one file
+    char path[1024];
+    sprintf(path, "breakfast/quiche");
+    lfs_file_open(&lfs, &files[0], path,
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    if (GC) {
+        lfs_fs_gc(&lfs) => 0;
+    }
+    size_t size = strlen(names[0]);
+    for (lfs_size_t i = 0; i < SIZE; i += size) {
+        lfs_file_write(&lfs, &files[0], names[0], size) => size;
+    }
+    // sync?
+    if (SYNC) {
+        lfs_file_sync(&lfs, &files[0]) => 0;
+    }
+
+    // write the other file
+    sprintf(path, "breakfast/quiche");
+    lfs_file_open(&lfs, &files[1], path,
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+    if (GC) {
+        lfs_fs_gc(&lfs) => 0;
+    }
+    size = strlen(names[1]);
+    for (lfs_size_t i = 0; i < SIZE; i += size) {
+        lfs_file_write(&lfs, &files[1], names[1], size) => size;
+    }
+    // sync?
+    if (SYNC) {
+        lfs_file_sync(&lfs, &files[1]) => 0;
+    }
+
+    // try to read from both
+    for (int n = 0; n < FILES; n++) {
+        lfs_file_rewind(&lfs, &files[n]) => 0;
+        size_t size = strlen(names[n]);
+        for (lfs_size_t i = 0; i < SIZE; i += size) {
+            uint8_t buffer[1024];
+            lfs_file_read(&lfs, &files[n], buffer, size) => size;
+            assert(memcmp(buffer, names[n], size) == 0);
+        }
+    }
+    for (int n = 0; n < FILES; n++) {
+        lfs_file_close(&lfs, &files[n]) => 0;
+    }
+    lfs_unmount(&lfs) => 0;
+
+    // check after remounting
+    lfs_mount(&lfs, &cfg_) => 0;
+    {
+        // last one wins
+        int n = FILES-1;
+        char path[1024];
+        sprintf(path, "breakfast/quiche");
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, path, LFS_O_RDONLY) => 0;
+        size_t size = strlen(names[n]);
+        for (lfs_size_t i = 0; i < SIZE; i += size) {
+            uint8_t buffer[1024];
+            lfs_file_read(&lfs, &file, buffer, size) => size;
+            assert(memcmp(buffer, names[n], size) == 0);
+        }
+        lfs_file_close(&lfs, &file) => 0;
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
+# multiple handle allocation reuse test
+[cases.test_alloc_multihandle_reuse]
+defines.FILES = 2
+defines.SIZE = '(((BLOCK_SIZE-8)*(BLOCK_COUNT-6)) / (FILES+1))'
+defines.CYCLES = [1, 10]
+defines.INFER_BC = [false, true]
+defines.SYNC = [false, true]
+code = '''
+    const char *names[] = {"eggs", "spinach"};
+    lfs_file_t files[FILES];
+
+    lfs_t lfs;
+    lfs_format(&lfs, cfg) => 0;
+    struct lfs_config cfg_ = *cfg;
+    if (INFER_BC) {
+        cfg_.block_count = 0;
+    }
+
+    lfs_mount(&lfs, &cfg_) => 0;
+    lfs_mkdir(&lfs, "breakfast") => 0;
+
+    // write one file
+    char path[1024];
+    sprintf(path, "breakfast/quiche");
+    lfs_file_open(&lfs, &files[0], path,
+            LFS_O_RDWR | LFS_O_CREAT | LFS_O_EXCL) => 0;
+    if (GC) {
+        lfs_fs_gc(&lfs) => 0;
+    }
+    size_t size = strlen(names[0]);
+    for (lfs_size_t i = 0; i < SIZE; i += size) {
+        lfs_file_write(&lfs, &files[0], names[0], size) => size;
+    }
+    // sync?
+    if (SYNC) {
+        lfs_file_sync(&lfs, &files[0]) => 0;
+    }
+
+    for (int c = 0; c < CYCLES; c++) {
+        // write the other file
+        sprintf(path, "breakfast/quiche");
+        lfs_file_open(&lfs, &files[1], path,
+                LFS_O_RDWR | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+        if (GC) {
+            lfs_fs_gc(&lfs) => 0;
+        }
+        size = strlen(names[1]);
+        for (lfs_size_t i = 0; i < SIZE; i += size) {
+            lfs_file_write(&lfs, &files[1], names[1], size) => size;
+        }
+        // sync?
+        if (SYNC) {
+            lfs_file_sync(&lfs, &files[1]) => 0;
+        }
+
+        // try to read from both
+        for (int n = 0; n < FILES; n++) {
+            lfs_file_rewind(&lfs, &files[n]) => 0;
+            size_t size = strlen(names[n]);
+            for (lfs_size_t i = 0; i < SIZE; i += size) {
+                uint8_t buffer[1024];
+                lfs_file_read(&lfs, &files[n], buffer, size) => size;
+                assert(memcmp(buffer, names[n], size) == 0);
+            }
+        }
+
+        lfs_file_close(&lfs, &files[1]) => 0;
+    }
+    lfs_file_close(&lfs, &files[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+
+    // check after remounting
+    lfs_mount(&lfs, &cfg_) => 0;
+    {
+        // last one wins
+        int n = (SYNC) ? FILES-1 : 0;
+        char path[1024];
+        sprintf(path, "breakfast/quiche");
+        lfs_file_t file;
+        lfs_file_open(&lfs, &file, path, LFS_O_RDONLY) => 0;
+        size_t size = strlen(names[n]);
+        for (int i = 0; i < SIZE; i += size) {
+            uint8_t buffer[1024];
+            lfs_file_read(&lfs, &file, buffer, size) => size;
+            assert(memcmp(buffer, names[n], size) == 0);
+        }
+        lfs_file_close(&lfs, &file) => 0;
+    }
+    lfs_unmount(&lfs) => 0;
+'''
+
 # exhaustion test
 [cases.test_alloc_exhaustion]
 defines.INFER_BC = [false, true]


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><div class="d-flex flex-md-row flex-column" style="box-sizing: border-box; flex-direction: row !important; display: flex !important; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="d-flex flex-row flex-1 tmp-mb-3 wb-break-word" style="box-sizing: border-box; flex-direction: row !important; flex-grow: 1 !important; flex-shrink: 1 !important; flex-basis: 0%; word-break: break-word !important; overflow-wrap: break-word !important; display: flex !important; margin-bottom: 16px !important;"><div class="flex-1" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; flex-grow: 1 !important; flex-shrink: 1 !important; flex-basis: 0%;"><h1 data-view-component="true" class="tmp-mr-3 d-inline" style="box-sizing: border-box; margin-top: 0px; margin-right: 16px !important; margin-bottom: 0px; margin-left: 0px; font-size: 32px; font-weight: 600; display: inline !important;">v2.11.3</h1><span> </span><span style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/releases/latest" data-view-component="true" class="Link v-align-text-bottom d-none d-md-inline-block" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: none; vertical-align: text-bottom !important; display: inline-block !important;"><span data-view-component="true" class="Label Label--success Label--large" style="box-sizing: border-box; border-color: rgb(35, 134, 54); border-style: solid; border-width: 0.666667px; border-image: none 100% / 1 / 0 stretch; border-radius: 9999.01px; font-size: 12px; font-weight: 500; padding: 0px 8px; white-space: nowrap; line-height: 22px; display: inline-block; color: rgb(63, 185, 80);">Latest</span></a><div class="ml-2 d-none d-md-inline" style="box-sizing: border-box; margin-left: 8px !important; display: inline !important;"></div></span></div></div><div class="d-flex tmp-mb-3" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; display: flex !important; margin-bottom: 16px !important;"><select-panel id="select-panel-e37823d8-455c-4068-8e52-5dffcc2ee003" anchor-align="start" anchor-side="outside-bottom" data-select-variant="single" data-fetch-strategy="eventually_local" data-open-on-load="false" data-view-component="true" data-catalyst="" style="box-sizing: border-box; display: block;"><dialog-helper style="box-sizing: border-box;"><button id="select-panel-e37823d8-455c-4068-8e52-5dffcc2ee003-button" aria-controls="select-panel-e37823d8-455c-4068-8e52-5dffcc2ee003-dialog" aria-haspopup="dialog" aria-expanded="false" type="button" data-view-component="true" class="Button--secondary Button--small Button" style="box-sizing: border-box; font-style: inherit; font-variant: inherit; font-weight: 500; font-stretch: inherit; font-size: 12px; line-height: inherit; font-family: inherit; font-optical-sizing: inherit; font-size-adjust: inherit; font-kerning: inherit; font-feature-settings: inherit; font-variation-settings: inherit; font-language-override: inherit; margin: 0px; overflow: visible; text-transform: none; appearance: button; cursor: pointer; border-radius: 6px; background-color: rgb(33, 40, 48); border-style: solid; border-width: 0.666667px; border-image: none 100% / 1 / 0 stretch; color: rgb(240, 246, 252); align-items: center; gap: 4px; height: 28px; min-width: 28px; padding: 0px 8px; text-align: center; transition: color 0.08s cubic-bezier(0.65, 0, 0.35, 1), fill, background-color, border-color; user-select: none; border-color: rgb(61, 68, 77); flex-direction: row; justify-content: space-between; display: inline-flex; position: relative; box-shadow: none; fill: rgb(145, 152, 161);"><span class="Button-content" style="box-sizing: border-box; flex: 1 0 auto; grid-template-columns: min-content minmax(0px, auto) min-content; grid-template-areas: &quot;leadingVisual text trailingVisual&quot;; place-content: center; align-items: center; display: grid;"><span class="Button-visual Button-trailingVisual" style="box-sizing: border-box; pointer-events: none; display: flex; grid-area: trailingVisual;"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-triangle-down"></svg></span></span></button></dialog-helper></select-panel></div></div><div class="tmp-mb-3 tmp-pb-md-4 border-md-bottom" data-pjax="#repo-content-pjax-container" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; border-bottom: 0.666667px solid rgb(61, 68, 77) !important; margin-bottom: 16px !important; padding-bottom: 24px !important; color: rgb(240, 246, 252); font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="d-flex flex-row flex-wrap color-fg-muted flex-items-end" style="box-sizing: border-box; color: rgb(145, 152, 161) !important; flex-flow: wrap !important; align-items: flex-end !important; display: flex !important;"><div class="tmp-mr-4 mb-2" style="box-sizing: border-box; margin-bottom: 8px !important; margin-right: 24px !important;"><img src="https://avatars.githubusercontent.com/u/35985906?s=40&amp;v=4" alt="@geky-bot" size="20" height="20" width="20" data-view-component="true" class="avatar avatar-small circle" style="box-sizing: border-box; border-style: none; border-radius: 3px; background-color: rgba(255, 255, 255, 0.1); box-shadow: rgba(255, 255, 255, 0.15) 0px 0px 0px 1px; vertical-align: middle; flex-shrink: 0; line-height: 1; display: inline-block; overflow: hidden;"><span> </span><a class="text-bold color-fg-muted" data-hovercard-type="user" data-hovercard-url="/users/geky-bot/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/geky-bot" aria-keyshortcuts="Alt+ArrowUp" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(145, 152, 161) !important; text-decoration: none; font-weight: 600 !important;">geky-bot</a><span> </span>released this<span> </span><relative-time class="no-wrap" prefix="" datetime="2026-03-25T02:26:59Z" title="Mar 25, 2026, 10:26 AM GMT+8" style="box-sizing: border-box; white-space: nowrap !important;">Mar 25</relative-time></div><div class="tmp-mr-4 mb-2" style="box-sizing: border-box; margin-bottom: 8px !important; margin-right: 24px !important;"><a href="https://github.com/littlefs-project/littlefs/tree/v2.11.3" data-view-component="true" class="Link Link--muted" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(145, 152, 161) !important; text-decoration: none;"><span data-view-component="true" class="css-truncate css-truncate-target" style="box-sizing: border-box; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; vertical-align: top; max-width: 125px; display: inline-block;"><svg aria-label="Tag" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-tag"><path d="M1 7.775V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 0 1 0 2.474l-5.026 5.026a1.75 1.75 0 0 1-2.474 0l-6.25-6.25A1.752 1.752 0 0 1 1 7.775Zm1.5 0c0 .066.026.13.073.177l6.25 6.25a.25.25 0 0 0 .354 0l5.025-5.025a.25.25 0 0 0 0-.354l-6.25-6.25a.25.25 0 0 0-.177-.073H2.75a.25.25 0 0 0-.25.25ZM6 5a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"></path></svg><span> </span><span class="ml-1" style="box-sizing: border-box; margin-left: 4px !important;">v2.11.3</span></span></a></div><div class="tmp-mr-4 mb-2" style="box-sizing: border-box; margin-bottom: 8px !important; margin-right: 24px !important; position: relative; top: 1px;"><a data-hovercard-type="commit" data-hovercard-url="/littlefs-project/littlefs/commit/6cb4e86540eca0d9ba62500a298385c9d863c8be/hovercard" href="https://github.com/littlefs-project/littlefs/commit/6cb4e86540eca0d9ba62500a298385c9d863c8be" data-view-component="true" class="Link Link--muted" aria-keyshortcuts="Alt+ArrowUp" data-turbo-frame="repo-content-turbo-frame" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(145, 152, 161) !important; text-decoration: none;"><svg aria-label="Commit" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-git-commit"><path d="M11.93 8.5a4.002 4.002 0 0 1-7.86 0H.75a.75.75 0 0 1 0-1.5h3.32a4.002 4.002 0 0 1 7.86 0h3.32a.75.75 0 0 1 0 1.5Zm-1.43-.75a2.5 2.5 0 1 0-5 0 2.5 2.5 0 0 0 5 0Z"></path></svg><span> </span><code class="f5 ml-1" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 14px !important; margin-left: 4px !important; tab-size: 4;">6cb4e86</code></a><span> </span><details class="dropdown dropdown-signed-commit details-reset details-overlay js-dropdown-details d-inline-block ml-1" style="box-sizing: border-box; display: inline-block !important; margin-left: 4px !important; position: relative;"><summary class="color-fg-success" style="box-sizing: border-box; display: list-item; cursor: pointer; color: rgb(63, 185, 80) !important; list-style: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color 80ms cubic-bezier(0.33, 1, 0.68, 1), box-shadow 80ms cubic-bezier(0.33, 1, 0.68, 1), border-color 80ms cubic-bezier(0.33, 1, 0.68, 1);"><svg aria-label="Verified commit signature" role="img" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-verified"><path d="m9.585.52.929.68c.153.112.331.186.518.215l1.138.175a2.678 2.678 0 0 1 2.24 2.24l.174 1.139c.029.187.103.365.215.518l.68.928a2.677 2.677 0 0 1 0 3.17l-.68.928a1.174 1.174 0 0 0-.215.518l-.175 1.138a2.678 2.678 0 0 1-2.241 2.241l-1.138.175a1.17 1.17 0 0 0-.518.215l-.928.68a2.677 2.677 0 0 1-3.17 0l-.928-.68a1.174 1.174 0 0 0-.518-.215L3.83 14.41a2.678 2.678 0 0 1-2.24-2.24l-.175-1.138a1.17 1.17 0 0 0-.215-.518l-.68-.928a2.677 2.677 0 0 1 0-3.17l.68-.928c.112-.153.186-.331.215-.518l.175-1.14a2.678 2.678 0 0 1 2.24-2.24l1.139-.175c.187-.029.365-.103.518-.215l.928-.68a2.677 2.677 0 0 1 3.17 0ZM7.303 1.728l-.927.68a2.67 2.67 0 0 1-1.18.489l-1.137.174a1.179 1.179 0 0 0-.987.987l-.174 1.136a2.677 2.677 0 0 1-.489 1.18l-.68.928a1.18 1.18 0 0 0 0 1.394l.68.927c.256.348.424.753.489 1.18l.174 1.137c.078.509.478.909.987.987l1.136.174a2.67 2.67 0 0 1 1.18.489l.928.68c.414.305.979.305 1.394 0l.927-.68a2.67 2.67 0 0 1 1.18-.489l1.137-.174a1.18 1.18 0 0 0 .987-.987l.174-1.136a2.67 2.67 0 0 1 .489-1.18l.68-.928a1.176 1.176 0 0 0 0-1.394l-.68-.927a2.686 2.686 0 0 1-.489-1.18l-.174-1.137a1.179 1.179 0 0 0-.987-.987l-1.136-.174a2.677 2.677 0 0 1-1.18-.489l-.928-.68a1.176 1.176 0 0 0-1.394 0ZM11.28 6.78l-3.75 3.75a.75.75 0 0 1-1.06 0L4.72 8.78a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L7 8.94l3.22-3.22a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Z"></path></svg></summary></details></div></div></div><div data-pjax="true" data-test-selector="body-content" data-view-component="true" class="markdown-body tmp-my-3" style="box-sizing: border-box; font-family: &quot;Mona Sans VF&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; overflow-wrap: break-word; font-size: 16px; line-height: 1.5; margin-top: 16px !important; margin-bottom: 16px !important; color: rgb(240, 246, 252); font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(13, 17, 23); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><p style="box-sizing: border-box; margin-top: 0px !important; margin-bottom: 16px;"><strong style="box-sizing: border-box; font-weight: 600;">littlefs3 status:</strong><span> </span>in-progress, unstable (<a href="https://github.com/littlefs-project/littlefs/issues/1114#issuecomment-3932058541" data-hovercard-type="issue" data-hovercard-url="/littlefs-project/littlefs/issues/1114/hovercard" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;">update, now with plots!</a>).<br style="box-sizing: border-box;"><strong style="box-sizing: border-box; font-weight: 600;">littlefs2 status:</strong><span> </span>feature freeze.</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><strong style="box-sizing: border-box; font-weight: 600;">Notable fix:</strong><span> </span>This includes a fix for a bug found by<span> </span><a class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/Ictogan1/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/Ictogan1" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(240, 246, 252); text-decoration: underline; font-weight: 600; white-space: nowrap; text-underline-offset: 0.2rem;">@Ictogan1</a>, where multiple open write handles could lead to data corruption (<a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="4048528554" data-permission-text="Title is private" data-url="https://github.com/littlefs-project/littlefs/issues/1194" data-hovercard-type="pull_request" data-hovercard-url="/littlefs-project/littlefs/pull/1194/hovercard" href="https://github.com/littlefs-project/littlefs/pull/1194" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;">#1194</a>).</p>
  | Code | Stack | Structs |   | Coverage
-- | -- | -- | -- | -- | --
Default | 17200 B (+0.4%) | 1448 B (+0.0%) | 812 B (+0.0%) | Lines | 2449/2610 lines (+0.0%)
Readonly | 6234 B (+0.0%) | 448 B (+0.0%) | 812 B (+0.0%) | Branches | 1301/1638 branches (+0.1%)
Threadsafe | 18056 B (+0.4%) | 1448 B (+0.0%) | 820 B (+0.0%) |   | Benchmarks
Multiversion | 17272 B (+0.4%) | 1448 B (+0.0%) | 816 B (+0.0%) | Readed | 29000746676 B (+0.0%)
Migrate | 18864 B (+0.4%) | 1752 B (+0.0%) | 816 B (+0.0%) | Proged | 1482895246 B (+0.0%)
Error-asserts | 18036 B (+0.5%) | 1440 B (+0.0%) | 812 B (+0.0%) | Erased | 1568921600 B (+0.0%)

<p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px;"><a href="https://github.com/littlefs-project/littlefs/commit/488e84bb" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">488e84bb</code></a><span> </span>Fixed data corruption with multiple write handles<br style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/commit/fd5e7f62" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">fd5e7f62</code></a><span> </span>Using LFS_ASSERT instead of an runtime check.<br style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/commit/2311cd78" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">2311cd78</code></a><span> </span>Guard null callbacks in lfs_dir_fetchmatch<br style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/commit/74f32c83" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">74f32c83</code></a><span> </span>Fix broken link on README.md for emu device<br style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/commit/dbe96d03" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">dbe96d03</code></a><span> </span>Fixes for 'Implicit conversion loses integer precision' warnings.<br style="box-sizing: border-box;"><a href="https://github.com/littlefs-project/littlefs/commit/b062c88a" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(68, 147, 248); text-decoration: underline; text-underline-offset: 0.2rem;"><code style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 13.6px; tab-size: 4; white-space: break-spaces; background-color: rgba(101, 108, 118, 0.2); border-radius: 6px; margin: 0px; padding: 0.2em 0.4em;">b062c88a</code></a><span> </span>Fix comment typo and -&gt; an</p><p style="box-sizing: border-box; margin-top: 0px; margin-bottom: 0px !important;">A special thanks to littlefs's sponsors:<span> </span><a class="user-mention notranslate" data-hovercard-type="organization" data-hovercard-url="/orgs/micropython/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/micropython" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(240, 246, 252); text-decoration: underline; font-weight: 600; white-space: nowrap; text-underline-offset: 0.2rem;">@micropython</a>,<span> </span><a class="user-mention notranslate" data-hovercard-type="user" data-hovercard-url="/users/gurgalof/hovercard" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="https://github.com/gurgalof" aria-keyshortcuts="Alt+ArrowUp" style="box-sizing: border-box; background-color: rgba(0, 0, 0, 0); color: rgb(240, 246, 252); text-decoration: underline; font-weight: 600; white-space: nowrap; text-underline-offset: 0.2rem;">@gurgalof</a></p></div><!--EndFragment-->
</body>
</html>v2.11.3 [Latest](https://github.com/littlefs-project/littlefs/releases/latest)
@[geky-bot](https://github.com/geky-bot) geky-bot released this Mar 25
[ v2.11.3](https://github.com/littlefs-project/littlefs/tree/v2.11.3)
https://github.com/littlefs-project/littlefs/commit/6cb4e86540eca0d9ba62500a298385c9d863c8be 
littlefs3 status: in-progress, unstable (https://github.com/littlefs-project/littlefs/issues/1114#issuecomment-3932058541).
littlefs2 status: feature freeze.

Notable fix: This includes a fix for a bug found by @Ictogan1, where multiple open write handles could lead to data corruption (https://github.com/littlefs-project/littlefs/pull/1194).

Code	Stack	Structs		Coverage
Default	17200 B (+0.4%)	1448 B (+0.0%)	812 B (+0.0%)	Lines	2449/2610 lines (+0.0%)
Readonly	6234 B (+0.0%)	448 B (+0.0%)	812 B (+0.0%)	Branches	1301/1638 branches (+0.1%)
Threadsafe	18056 B (+0.4%)	1448 B (+0.0%)	820 B (+0.0%)		Benchmarks
Multiversion	17272 B (+0.4%)	1448 B (+0.0%)	816 B (+0.0%)	Readed	29000746676 B (+0.0%)
Migrate	18864 B (+0.4%)	1752 B (+0.0%)	816 B (+0.0%)	Proged	1482895246 B (+0.0%)
Error-asserts	18036 B (+0.5%)	1440 B (+0.0%)	812 B (+0.0%)	Erased	1568921600 B (+0.0%)
[488e84bb](https://github.com/littlefs-project/littlefs/commit/488e84bb) Fixed data corruption with multiple write handles
[fd5e7f62](https://github.com/littlefs-project/littlefs/commit/fd5e7f62) Using LFS_ASSERT instead of an runtime check.
[2311cd78](https://github.com/littlefs-project/littlefs/commit/2311cd78) Guard null callbacks in lfs_dir_fetchmatch
[74f32c83](https://github.com/littlefs-project/littlefs/commit/74f32c83) Fix broken link on README.md for emu device
[dbe96d03](https://github.com/littlefs-project/littlefs/commit/dbe96d03) Fixes for 'Implicit conversion loses integer precision' warnings.
[b062c88a](https://github.com/littlefs-project/littlefs/commit/b062c88a) Fix comment typo and -> an

A special thanks to littlefs's sponsors: https://github.com/micropython, @gurgalof

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handle state synchronization and error handling across multiple file operations to enhance system reliability and consistency.
  * Enhanced type safety in critical internal calculations.

* **Tests**
  * Added comprehensive test cases for multi-handle file allocation scenarios, including garbage collection and remount verification to ensure correctness.

* **Documentation**
  * Updated testing section reference for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->