### PR TITLE
fix[DFS][littlefs]: align lseek callback signature with off_t

### DIFF
--- a/dfs_lfs.c
+++ b/dfs_lfs.c
@@ -85,10 +85,10 @@
 #define DFS_LFS_FILE_FS(file)                       ((file)->vnode->fs)
 #define DFS_LFS_READ_PARAMS                         DFS_LFS_FILE_STRUCT* file, void* buf, size_t len
 #define DFS_LFS_WRITE_PARAMS                        DFS_LFS_FILE_STRUCT* file, const void* buf, size_t len
-#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, rt_off_t offset
+#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, off_t offset
 #define DFS_LFS_IO_POS_PARAM                        RT_NULL
 #define DFS_LFS_LSEEK_WHENCE                        SEEK_SET
-#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (rt_off_t)(lfs_pos))
+#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (off_t)(lfs_pos))
 #define DFS_LFS_FS_FLAGS                            DFS_FS_FLAG_DEFAULT
 #define DFS_LFS_REGISTER()                          dfs_register(&_dfs_lfs_ops)
 #elif defined(RT_USING_DFS_V1)
@@ -114,10 +114,10 @@
 #define DFS_LFS_FILE_FS(file)                       ((file)->vnode->fs)
 #define DFS_LFS_READ_PARAMS                         DFS_LFS_FILE_STRUCT* file, void* buf, size_t len
 #define DFS_LFS_WRITE_PARAMS                        DFS_LFS_FILE_STRUCT* file, const void* buf, size_t len
-#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, rt_off_t offset
+#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, off_t offset
 #define DFS_LFS_IO_POS_PARAM                        RT_NULL
 #define DFS_LFS_LSEEK_WHENCE                        SEEK_SET
-#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (rt_off_t)(lfs_pos))
+#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (off_t)(lfs_pos))
 #define DFS_LFS_FS_FLAGS                            DFS_FS_FLAG_DEFAULT
 #define DFS_LFS_REGISTER()                          dfs_register(&_dfs_lfs_ops)
 #elif defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 0))
@@ -142,10 +142,10 @@
 #define DFS_LFS_FILE_FS(file)                       ((file)->vnode->fs)
 #define DFS_LFS_READ_PARAMS                         DFS_LFS_FILE_STRUCT* file, void* buf, size_t len
 #define DFS_LFS_WRITE_PARAMS                        DFS_LFS_FILE_STRUCT* file, const void* buf, size_t len
-#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, rt_off_t offset
+#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, off_t offset
 #define DFS_LFS_IO_POS_PARAM                        RT_NULL
 #define DFS_LFS_LSEEK_WHENCE                        SEEK_SET
-#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (rt_off_t)(lfs_pos))
+#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (off_t)(lfs_pos))
 #define DFS_LFS_FS_FLAGS                            DFS_FS_FLAG_DEFAULT
 #define DFS_LFS_REGISTER()                          dfs_register(&_dfs_lfs_ops)
 #else
@@ -170,10 +170,10 @@
 #define DFS_LFS_FILE_FS(file)                       ((file)->fs)
 #define DFS_LFS_READ_PARAMS                         DFS_LFS_FILE_STRUCT* file, void* buf, size_t len
 #define DFS_LFS_WRITE_PARAMS                        DFS_LFS_FILE_STRUCT* file, const void* buf, size_t len
-#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, rt_off_t offset
+#define DFS_LFS_LSEEK_PARAMS                        DFS_LFS_FILE_STRUCT* file, off_t offset
 #define DFS_LFS_IO_POS_PARAM                        RT_NULL
 #define DFS_LFS_LSEEK_WHENCE                        SEEK_SET
-#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (rt_off_t)(lfs_pos))
+#define DFS_LFS_STORE_FILE_POS(file, pos, lfs_pos)  (DFS_LFS_FILE_POS(file) = (off_t)(lfs_pos))
 #define DFS_LFS_FS_FLAGS                            DFS_FS_FLAG_DEFAULT
 #define DFS_LFS_REGISTER()                          dfs_register(&_dfs_lfs_ops)
 #endif /* defined(RT_USING_DFS_V2) */
@@ -979,14 +979,14 @@ static int _dfs_lfs_ioctl(DFS_LFS_FILE_STRUCT* file, int cmd, void* args)
         {
             return _lfs_result_to_dfs((int)pos);
         }
-        DFS_LFS_FILE_POS(file) = (rt_off_t)pos;
+        DFS_LFS_FILE_POS(file) = (off_t)pos;
 
         pos = lfs_file_size(dfs_lfs_fd->lfs, &dfs_lfs_fd->u.file);
         if (pos < 0)
         {
             return _lfs_result_to_dfs((int)pos);
         }
-        DFS_LFS_FILE_SIZE(file) = (rt_off_t)pos;
+        DFS_LFS_FILE_SIZE(file) = (size_t)pos;
 
         return RT_EOK;
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

[RT-Thread PR #11486](https://github.com/RT-Thread/rt-thread/pull/11486) 中反馈，最新版 littlefs 在 Keil 编译场景下会出现 DFS `lseek` 回调函数指针类型不兼容问题：DFS 文件操作表期望 `off_t (*)(struct dfs_file *, off_t)`，但 littlefs 适配层当前非 DFS_V2 分支的 `_dfs_lfs_lseek` 参数通过 `DFS_LFS_LSEEK_PARAMS` 展开为 `rt_off_t offset`。

虽然 `rt_off_t` 在 RT-Thread 中确实存在，并定义为 `rt_base_t`，但它不等价于 DFS `lseek` 接口签名要求中的 `off_t`。在部分工具链/配置下，`rt_off_t` 的底层类型可能是 `signed int`，而 `off_t` 的底层类型可能是 `signed long`，从而导致函数指针签名不兼容。

我这里使用 GCC + DFS_V1 没有出现 warning。分析原因是该构建使用了 newlib，并定义了 `RT_USING_LIBC`；通过工具查看最终链路可见该 GCC 工具链中 `__INT32_TYPE__` 为 `long int`，因此 `rt_off_t` 最终也会落到 `long`，未触发类型不兼容问题。

littlefs 当前 CI 编译使用 `bsp/qemu-vexpress-a9`，该路径没有暴露问题；由于没有很好的方案在 CI 中模拟 Keil/IAR 的具体 typedef 实现，这一类兼容性仍需要实际 Keil/IAR 工程验证。

#### 你的解决方案是什么 (what is your solution)

1. 将非 DFS_V2 分支中的 `DFS_LFS_LSEEK_PARAMS` 从 `rt_off_t offset` 改为 `off_t offset`，使 `_dfs_lfs_lseek` 的函数签名与 RT-Thread DFS `lseek` 回调原型保持一致。
2. 将 littlefs 文件位置回写处统一按 DFS 文件结构字段类型处理：文件当前位置使用 `off_t`，文件大小使用 `size_t`。
3. 加入参数接口签名检查，使 RT-Thread 5.0.2 及之后的 DFS_V1 配置在编译期确认 `_dfs_lfs_lseek` 与 DFS 期望的 `lseek` 签名一致：

```c
#if !defined(RT_USING_DFS_V2) && defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 2))
typedef off_t (*dfs_lfs_lseek_expected_t)(struct dfs_file *file, off_t offset);
static dfs_lfs_lseek_expected_t dfs_lfs_lseek_type_check = _dfs_lfs_lseek;
#endif /* !defined(RT_USING_DFS_V2) && defined(RT_VERSION_CHECK) && (RTTHREAD_VERSION >= RT_VERSION_CHECK(5, 0, 2)) */
```

这里检查变量绑定到实际的静态函数 `_dfs_lfs_lseek`，避免仅修改函数实现但没有覆盖到 DFS 回调签名的问题。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

`bsp/qemu-vexpress-a9`，用于 littlefs 现有 GCC CI 路径验证。Keil/IAR 兼容性问题来源于 RT-Thread PR #11486 中的实际工程反馈，仍建议在受影响的 Keil/IAR 工程中做最终验证。

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

无需新增配置项。相关验证配置包括：

```text
RT_USING_DFS_V1
PKG_USING_LITTLEFS
```

GCC 未复现 warning 的路径还包含 `RT_USING_LIBC` / newlib 的类型定义影响。

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

not provided yet. 现有 littlefs CI 使用 `bsp/qemu-vexpress-a9`，不能覆盖 Keil/IAR 的 typedef 差异；Keil/IAR 仍需实际工程验证。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved file truncation and position handling in LittleFS operations for better compatibility across different RT-Thread versions and build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->